### PR TITLE
Deatached mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ To further enhance your setup, you can also utilise the `--external-network` fla
 
 For more details on using the `--external-network` flag, refer to the [External Network Guide](docs/external-network.md).
 
+To start run-o11y-run in `detached` mode, use the `--detach` flag. This will start the containers in the background.
+
 ### Stop Command
 
 The `stop` command is used to gracefully stop the run-o11y-run containers. It ensures a clean shutdown of your observability stack. Here's an example of using the `stop` command:

--- a/internal/cli/clean.go
+++ b/internal/cli/clean.go
@@ -38,13 +38,13 @@ func genCleanCommand() *cli.Command {
 			}
 
 			if c.Bool("legacy") {
-				err = runDockerCompose(filepath.Join(targetDir, "files", "grafana", "stack"), "down", "")
+				err = runDockerCompose(filepath.Join(targetDir, "files", "grafana", "stack"), "down")
 				if err != nil {
 					fmt.Println("Error running docker compose down:", err)
 					return err
 				}
 			} else {
-				err = runDockerCompose(filepath.Join(targetDir, "files", "grafana", "run-o11y-run"), "down", "")
+				err = runDockerCompose(filepath.Join(targetDir, "files", "grafana", "run-o11y-run"), "down")
 				if err != nil {
 					fmt.Println("Error running docker compose down:", err)
 					return err

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/urfave/cli/v2"
+	"golang.org/x/exp/slices"
 )
 
 func initBanner(c *cli.Context) error {
@@ -88,6 +89,10 @@ func runDockerCompose(dir, subcommand string, flags ...string) error {
 	err := cmd.Start()
 	if err != nil {
 		return fmt.Errorf("docker compose %s failed: %w", subcommand, err)
+	}
+	if slices.Contains(args, "--detach") {
+		fmt.Println("🚀 Started in detached mode")
+		return nil
 	}
 	if subcommand == "down" {
 		err = cmd.Wait()

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -76,11 +76,9 @@ func removeDirectory(dir string) error {
 }
 
 // runDockerCompose runs a docker compose command
-func runDockerCompose(dir, subcommand, flag string) error {
+func runDockerCompose(dir, subcommand string, flags ...string) error {
 	args := []string{"compose", subcommand}
-	if flag != "" {
-		args = append(args, flag)
-	}
+	args = append(args, flags...)
 
 	cmd := exec.Command("docker", args...)
 	cmd.Dir = dir
@@ -91,7 +89,6 @@ func runDockerCompose(dir, subcommand, flag string) error {
 	if err != nil {
 		return fmt.Errorf("docker compose %s failed: %w", subcommand, err)
 	}
-
 	if subcommand == "down" {
 		err = cmd.Wait()
 		if err != nil {

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -25,9 +25,14 @@ func genStartCommand() *cli.Command {
 				Value:   "registry-1.docker.io",
 			},
 			&cli.BoolFlag{
-				Name:    "debug",
-				Aliases: []string{"d"},
-				Usage:   "debug mode",
+				Name:  "debug",
+				Usage: "debug mode",
+				Value: false,
+			},
+			&cli.BoolFlag{
+				Name:    "detach",
+				Aliases: []string{"detached"},
+				Usage:   "deatched mode",
 				Value:   false,
 			},
 			&cli.BoolFlag{
@@ -78,13 +83,19 @@ func genStartCommand() *cli.Command {
 			}
 
 			// Run the Docker Compose up command
-			err = runDockerCompose(filepath.Join(targetDir, "files", "grafana", "run-o11y-run"), "up", "")
+			flags := make([]string, 0)
+			if c.Bool("detach") {
+				flags = append(flags, "--detach")
+			}
+
+			err = runDockerCompose(filepath.Join(targetDir, "files", "grafana", "run-o11y-run"), "up", flags...)
 			if err != nil {
 				fmt.Println("Error running docker compose up:", err)
 				return err
 			}
-
-			fmt.Println("🏁 Stopped...")
+			if !c.Bool("detach") {
+				fmt.Println("🏁 Stopped...")
+			}
 			return nil
 		},
 	}

--- a/internal/cli/stop.go
+++ b/internal/cli/stop.go
@@ -30,7 +30,7 @@ func genStopCommand() *cli.Command {
 				return err
 			}
 
-			err = runDockerCompose(filepath.Join(targetDir, "files", "grafana", "run-o11y-run"), "down", "")
+			err = runDockerCompose(filepath.Join(targetDir, "files", "grafana", "run-o11y-run"), "down")
 			if err != nil {
 				fmt.Println("Error running docker compose down:", err)
 				return err


### PR DESCRIPTION
To integrate `o11y-run` with 3rd party docker-compose I may need to run it in detached mode.
I can do it on the client side using bash, or within `o11y-run` which seems to be cleaner, so this is the PR to enable it.