### PR TITLE
feat: adding ports command

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,27 @@ The `clean` command is used to stop and remove run-o11y-run containers, files, a
 run-o11y-run clean
 ```
 
+### Ports Command
+
+The `ports` command allows you to list the available ports used by the application. It provides a convenient way to check which ports are used by various services within the observability stack.
+
+Here's an example output of the ports command:
+
+```sh
++-----------+-------------------+
+|   PORT    |      SERVICE      |
++-----------+-------------------+
+| 3000/tcp  | Grafana           |
+| 3100/tcp  | Loki              |
+| 4317/tcp  | OTLP (gRPC)       |
+| 4318/tcp  | OTLP (HTTP)       |
+| 8094/tcp  | Syslog (RFC3164)  |
+| 9090/tcp  | Prometheus Direct |
+| 9411/tcp  | Zipkin            |
+| 14268/tcp | Jaeger            |
++-----------+-------------------+
+```
+
 ## Local Service Links
 
 * [Grafana Loki](http://localhost:3000/explore?orgId=1&left=%7B%22datasource%22:%22P8E80F9AEF21F6940%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22P8E80F9AEF21F6940%22%7D%7D%5D,%22range%22:%7B%22from%22:%22now-1h%22,%22to%22:%22now%22%7D%7D)

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.20
 
 require (
 	github.com/fatih/color v1.15.0
+	github.com/olekukonko/tablewriter v0.0.5
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	github.com/urfave/cli/v2 v2.25.3
 	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1
@@ -15,6 +16,7 @@ require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.17 // indirect
+	github.com/mattn/go-runewidth v0.0.9 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
 	golang.org/x/sys v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,10 @@ github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovk
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.17 h1:BTarxUcIeDqL27Mc+vyvdWYSL28zpIhv3RoTdsLMPng=
 github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
+github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
+github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
+github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
+github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 h1:KoWmjvw+nsYOo29YJK9vDA65RGE3NrOnUtO7a+RF9HU=
 github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8/go.mod h1:HKlIX3XHQyzLZPlr7++PzdhaXEj94dEiJgZDTsxEqUI=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -55,6 +55,7 @@ func New(version, commit, date string) *cli.App {
 		Commands: []*cli.Command{
 			genCleanCommand(),
 			genOpenCommand(),
+			genPortsCommand(),
 			genStartCommand(),
 			genStopCommand(),
 		},

--- a/internal/cli/ports.go
+++ b/internal/cli/ports.go
@@ -1,0 +1,49 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/olekukonko/tablewriter"
+	"github.com/urfave/cli/v2"
+)
+
+// genPortsCommand generates the ports command
+func genPortsCommand() *cli.Command {
+	return &cli.Command{
+		Name:    "ports",
+		Usage:   "List the available ports used by run-o11y-run",
+		Aliases: []string{"p"},
+		Action: func(c *cli.Context) error {
+			data := [][]string{
+				{"3000/tcp", "Grafana"},
+				{"3100/tcp", "Loki"},
+				{"4317/tcp", "OTLP (gRPC)"},
+				{"4318/tcp", "OTLP (HTTP)"},
+				{"8094/tcp", "Syslog (RFC3164)"},
+				{"9090/tcp", "Prometheus Direct"},
+				{"9411/tcp", "Zipkin"},
+				{"14268/tcp", "Jaeger"},
+			}
+
+			fmt.Println()
+			table := tablewriter.NewWriter(os.Stdout)
+			table.SetHeader([]string{"Port", "Service"})
+			table.SetAutoFormatHeaders(true)
+			table.SetAlignment(tablewriter.ALIGN_LEFT)
+
+			table.SetHeaderColor(tablewriter.Colors{tablewriter.Bold},
+				tablewriter.Colors{tablewriter.Bold})
+
+			table.SetColumnColor(tablewriter.Colors{tablewriter.Bold, tablewriter.FgGreenColor},
+				tablewriter.Colors{tablewriter.Bold, tablewriter.FgCyanColor})
+
+			table.AppendBulk(data)
+			table.Render()
+
+			fmt.Println()
+
+			return nil
+		},
+	}
+}

--- a/internal/cli/ports.go
+++ b/internal/cli/ports.go
@@ -31,16 +31,12 @@ func genPortsCommand() *cli.Command {
 			table.SetHeader([]string{"Port", "Service"})
 			table.SetAutoFormatHeaders(true)
 			table.SetAlignment(tablewriter.ALIGN_LEFT)
-
 			table.SetHeaderColor(tablewriter.Colors{tablewriter.Bold},
 				tablewriter.Colors{tablewriter.Bold})
-
 			table.SetColumnColor(tablewriter.Colors{tablewriter.Bold, tablewriter.FgGreenColor},
 				tablewriter.Colors{tablewriter.Bold, tablewriter.FgCyanColor})
-
 			table.AppendBulk(data)
 			table.Render()
-
 			fmt.Println()
 
 			return nil


### PR DESCRIPTION
Adding `ports` command with table output:

```sh
+-----------+-------------------+
|   PORT    |      SERVICE      |
+-----------+-------------------+
| 3000/tcp  | Grafana           |
| 3100/tcp  | Loki              |
| 4317/tcp  | OTLP (gRPC)       |
| 4318/tcp  | OTLP (HTTP)       |
| 8094/tcp  | Syslog (RFC3164)  |
| 9090/tcp  | Prometheus Direct |
| 9411/tcp  | Zipkin            |
| 14268/tcp | Jaeger            |
+-----------+-------------------+
```