### PR TITLE
feat: add pyroscope and yolo

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The underlying observability stack is built on [Grafana](https://grafana.com/) p
 * [MinIO](https://min.io/)
 * [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/)
 * [Prometheus](https://grafana.com/oss/prometheus/)
-
+* [Pyroscope](https://pyroscope.io/)
 
 ## Prerequisites
 
@@ -48,9 +48,10 @@ Download the latest version from the [Releases](https://github.com/krzko/run-o11
     * OTLP (http): http://localhost:4318
     * Jaeger: http://localhost:14268
     * Zipkin: http://localhost:9411
-* Logs are procedd via two means:
+* Logs are processed via two means:
   * Tailed from `/var/log/*.log` and `./*.log` on your local machine.
   * A Syslog RFC 3164 header format, `syslog` receiver operates on `localhost:8094`
+* Profiling data can be pushed to http://localhost:4040
 * To exit gracefully, press `CTRL+C`.
 
 ## Commands
@@ -86,6 +87,10 @@ To further enhance your setup, you can also utilise the `--external-network` fla
 
 To start run-o11y-run in `detached` mode, use the `--detach` flag. This will start the containers in the background.
 
+The `--yolo` flag can be used with the run-o11y-run command to apply the `:latest` tag to all images in your stack. This flag allows you to conveniently run the latest versions of the images without specifying the specific tags.
+
+  * **NOTE:** However, please note that using the `--yolo` flag may introduce potential risks, as it may lead to compatibility issues or unexpected behaviour if the latest images have breaking changes or dependencies
+
 For more details on using the `--external-network` flag, refer to the [External Network](docs/external-network.md) guide.
 
 ### Stop Command
@@ -101,7 +106,7 @@ run-o11y-run stop
 The `open` command allows you to conveniently open various services provided by run-o11y-run in your default web browser. This feature saves you time by quickly launching the relevant service pages.:
 
 ```sh
-run-o11y-run open --service <loki|tempo|prometheus|prometheus-direct>
+run-o11y-run open --service <loki|tempo|prometheus|prometheus-direct|pyroscope-direct>
 ```
 
 Ensure that run-o11y-run is already running before using the open command.
@@ -128,6 +133,7 @@ Here's an example output of the ports command:
 +-----------+-------------------+
 | 3000/tcp  | Grafana           |
 | 3100/tcp  | Loki              |
+| 4040/tcp  | Pyropscope        |
 | 4317/tcp  | OTLP (gRPC)       |
 | 4318/tcp  | OTLP (HTTP)       |
 | 8094/tcp  | Syslog (RFC3164)  |
@@ -143,9 +149,11 @@ Here's an example output of the ports command:
 * [Grafana Tempo](http://localhost:3000/explore?orgId=1&left=%7B%22datasource%22:%22tempo%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22datasource%22:%7B%22type%22:%22tempo%22,%22uid%22:%22tempo%22%7D%7D%5D,%22range%22:%7B%22from%22:%22now-1h%22,%22to%22:%22now%22%7D%7D)
 * [Grafana Prometheus](http://localhost:3000/explore?orgId=1&left=%7B%22datasource%22:%22prometheus%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22prometheus%22%7D%7D%5D,%22range%22:%7B%22from%22:%22now-1h%22,%22to%22:%22now%22%7D%7D)
 * [Prometheus Direct](http://localhost:9090/)
+* [Pyroscope Direct](http://localhost:4040/)
 
 ## Documentation
 
+* [FlameQL](https://pyroscope.io/docs/flameql/)
 * [LogQL](https://grafana.com/docs/loki/latest/logql/)
 * [PromQL](https://prometheus.io/docs/prometheus/latest/querying/basics/)
 * [TraceQL](https://grafana.com/docs/tempo/latest/traceql/)

--- a/internal/cli/open.go
+++ b/internal/cli/open.go
@@ -17,7 +17,7 @@ func genOpenCommand() *cli.Command {
 			&cli.StringFlag{
 				Name:     "service",
 				Aliases:  []string{"s"},
-				Usage:    "specify the service to open: loki, tempo, prometheus, or prometheus-direct",
+				Usage:    "specify the service to open: loki, tempo, prometheus, prometheus-direct or pyroscope-direct",
 				Required: true,
 			},
 		},
@@ -34,6 +34,8 @@ func genOpenCommand() *cli.Command {
 				url = "http://localhost:3000/explore?orgId=1&left=%7B%22datasource%22:%22prometheus%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22prometheus%22%7D%7D%5D,%22range%22:%7B%22from%22:%22now-1h%22,%22to%22:%22now%22%7D%7D"
 			case "prometheus-direct":
 				url = "http://localhost:9090/"
+			case "pyroscope-direct":
+				url = "http://localhost:4040/"
 			default:
 				return fmt.Errorf("unsupported service")
 			}

--- a/internal/cli/ports.go
+++ b/internal/cli/ports.go
@@ -18,6 +18,7 @@ func genPortsCommand() *cli.Command {
 			data := [][]string{
 				{"3000/tcp", "Grafana"},
 				{"3100/tcp", "Loki"},
+				{"4040/tcp", "Pyroscope"},
 				{"4317/tcp", "OTLP (gRPC)"},
 				{"4318/tcp", "OTLP (HTTP)"},
 				{"8094/tcp", "Syslog (RFC3164)"},

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/krzko/run-o11y-run/internal/files"
 	"github.com/urfave/cli/v2"
@@ -40,6 +41,11 @@ func genStartCommand() *cli.Command {
 				Usage: "external network mode for docker compose",
 				Value: false,
 			},
+			&cli.BoolFlag{
+				Name:  "yolo",
+				Usage: "apply the :latest tag to all images. Caution: This may result in breaking changes to the setup",
+				Value: false,
+			},
 		},
 		Action: func(c *cli.Context) error {
 			fmt.Println("✨ Starting...")
@@ -63,6 +69,14 @@ func genStartCommand() *cli.Command {
 			if err = addRegistryPrefix(dockerComposePath, c.String("registry")); err != nil {
 				fmt.Println("Error adding registry prefix to Docker Compose file:", err)
 				return err
+			}
+
+			// Add :latest tag to images if specified
+			if c.Bool("yolo") {
+				if err = addLatestTag(dockerComposePath); err != nil {
+					fmt.Println("Error adding :latest tag to Docker Compose file:", err)
+					return err
+				}
 			}
 
 			// Modify the Docker Compose to expose named network for other Docker Composes
@@ -100,36 +114,6 @@ func genStartCommand() *cli.Command {
 			return nil
 		},
 	}
-}
-
-// addRegistryPrefix adds the registry prefix to the image field of the Docker Compose file
-func addRegistryPrefix(filePath, registry string) error {
-	// Read the Docker Compose file
-	composeMap, err := dockeComposeMap(filePath)
-	if err != nil {
-		return err
-	}
-
-	// Modify the image field with the registry prefix for all services
-	services, ok := composeMap["services"].(map[any]any)
-	if ok {
-		for name, sAny := range services {
-			service, ok := sAny.(map[any]any)
-			if !ok {
-				return fmt.Errorf("unexpected type for service")
-			}
-			image, ok := service["image"].(string)
-			if ok {
-				service["image"] = fmt.Sprintf("%s/%s", registry, image)
-			} else {
-				return fmt.Errorf("error during injecting external registry to service(%s) image definition", name)
-			}
-		}
-	} else {
-		return fmt.Errorf("error during injecting external registry to service image definition")
-	}
-
-	return writeDockerCompose(filePath, composeMap)
 }
 
 // addExternalNetwork adds the registry prefix to the image field of the Docker Compose file
@@ -170,6 +154,69 @@ func addExternalNetwork(filePath string) error {
 			"attachable": true,
 		},
 	}
+	return writeDockerCompose(filePath, composeMap)
+}
+
+// addLatestTag replaces the tag portion of the image field with "latest" in the Docker Compose file
+func addLatestTag(filePath string) error {
+	// Read the Docker Compose file
+	composeMap, err := dockeComposeMap(filePath)
+	if err != nil {
+		return err
+	}
+
+	// Modify the image field with "latest" tag for all services
+	services, ok := composeMap["services"].(map[interface{}]interface{})
+	if ok {
+		for name, sAny := range services {
+			service, ok := sAny.(map[any]any)
+			if !ok {
+				return fmt.Errorf("unexpected type for service")
+			}
+			image, ok := service["image"].(string)
+			if ok {
+				parts := strings.SplitN(image, ":", 2)
+				if len(parts) == 2 {
+					service["image"] = fmt.Sprintf("%s:latest", parts[0])
+				}
+			} else {
+				return fmt.Errorf("error during adding 'latest' tag to service(%s) image definition", name)
+			}
+		}
+	} else {
+		return fmt.Errorf("error during adding 'latest' tag to service image definition")
+	}
+
+	return writeDockerCompose(filePath, composeMap)
+}
+
+// addRegistryPrefix adds the registry prefix to the image field of the Docker Compose file
+func addRegistryPrefix(filePath, registry string) error {
+	// Read the Docker Compose file
+	composeMap, err := dockeComposeMap(filePath)
+	if err != nil {
+		return err
+	}
+
+	// Modify the image field with the registry prefix for all services
+	services, ok := composeMap["services"].(map[any]any)
+	if ok {
+		for name, sAny := range services {
+			service, ok := sAny.(map[any]any)
+			if !ok {
+				return fmt.Errorf("unexpected type for service")
+			}
+			image, ok := service["image"].(string)
+			if ok {
+				service["image"] = fmt.Sprintf("%s/%s", registry, image)
+			} else {
+				return fmt.Errorf("error during injecting external registry to service(%s) image definition", name)
+			}
+		}
+	} else {
+		return fmt.Errorf("error during injecting external registry to service image definition")
+	}
+
 	return writeDockerCompose(filePath, composeMap)
 }
 

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -136,7 +136,7 @@ func addExternalNetwork(filePath string) error {
 			name, _ := nAny.(string)
 			// inject o11y network only to otel-collector and tempo service.
 			// other services like mini-o11y-stack, grafana, etc. should not be exposed.
-			if slices.Contains([]string{"otel-collector", "tempo"}, name) {
+			if slices.Contains([]string{"otel-collector", "pyroscope", "tempo"}, name) {
 				service["networks"] = []string{"o11y", "default"}
 			}
 		}

--- a/internal/files/files/grafana/run-o11y-run/docker-compose.yaml
+++ b/internal/files/files/grafana/run-o11y-run/docker-compose.yaml
@@ -6,12 +6,15 @@ services:
     image: grafana/grafana:9.4.3
     volumes:
       - ../shared/grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
+      # - ../shared/pyroscope/grafana-provisioning:/etc/grafana/provisioning
+      # - ../shared/pyroscope-dashboard.json:/etc/grafana/provisioning/dashboards/dashboard.json
     environment:
       - GF_AUTH_ANONYMOUS_ENABLED=true
       - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
       - GF_AUTH_DISABLE_LOGIN_FORM=true
       - GF_FEATURE_TOGGLES_ENABLE=traceqlEditor
-      - NO_PROXY=grafana,loki,minio,ote-collector,prometheus,tempo
+      # - GF_INSTALL_PLUGINS=pyroscope-datasource,pyroscope-panel
+      - NO_PROXY=rafana,loki,minio,ote-collector,prometheus,pyroscope,tempo
     ports:
       - "3000:3000"
 
@@ -19,7 +22,7 @@ services:
     image: grafana/loki:2.8.2
     command: "-config.file=/etc/loki/local-config.yaml"
     environment:
-      - NO_PROXY=grafana,loki,minio,ote-collector,prometheus,tempo
+      - NO_PROXY=rafana,loki,minio,ote-collector,prometheus,pyroscope,tempo
     ports:
       - "3100:3100"
       - 7946
@@ -48,7 +51,7 @@ services:
       - MINIO_ROOT_PASSWORD=supersecret
       - MINIO_PROMETHEUS_AUTH_TYPE=public
       - MINIO_UPDATE=off
-      - NO_PROXY=grafana,loki,minio,ote-collector,prometheus,tempo
+      - NO_PROXY=rafana,loki,minio,ote-collector,prometheus,pyroscope,tempo
     ports:
       - 9000
     volumes:
@@ -71,7 +74,7 @@ services:
       - "4318:4318"   # otlp http
       - "8094:8094"   # syslog
     environment:
-      - NO_PROXY=grafana,loki,minio,ote-collector,prometheus,tempo
+      - NO_PROXY=rafana,loki,minio,ote-collector,prometheus,pyroscope,tempo
     depends_on:
       - loki
       - prometheus
@@ -88,7 +91,18 @@ services:
     ports:
       - "9090:9090"
     environment:
-      - NO_PROXY=grafana,loki,minio,ote-collector,prometheus,tempo
+      - NO_PROXY=rafana,loki,minio,ote-collector,prometheus,pyroscope,tempo
+
+  pyroscope:
+    image: pyroscope/pyroscope:0.37.2
+    ports:
+      - "4040:4040"
+    command:
+      - server
+    environment:
+      - NO_PROXY=grafana,loki,minio,ote-collector,prometheus,pyroscope,tempo
+      - PYROSCOPE_LOG_LEVEL=info
+      - PYROSCOPE_WAIT_AFTER_STOP=true
 
   tempo:
     image: grafana/tempo:main-5e0870a
@@ -102,4 +116,4 @@ services:
       - "9095:9095"   # tempo grpc
       - "9411:9411"   # zipkin
     environment:
-      - NO_PROXY=grafana,loki,minio,ote-collector,prometheus,tempo
+      - NO_PROXY=rafana,loki,minio,ote-collector,prometheus,pyroscope,tempo

--- a/internal/files/files/grafana/shared/grafana-datasources.yaml
+++ b/internal/files/files/grafana/shared/grafana-datasources.yaml
@@ -1,42 +1,55 @@
 apiVersion: 1
 
 datasources:
-- name: Loki
-  type: loki
-  # uid: prometheus
-  access: proxy
-  orgId: 1
-  url: http://loki:3100
-  basicAuth: false
-  isDefault: false
-  version: 1
-  editable: false
-  jsonData:
-    httpMethod: GET
-- name: Prometheus
-  type: prometheus
-  uid: prometheus
-  access: proxy
-  orgId: 1
-  url: http://prometheus:9090
-  basicAuth: false
-  isDefault: false
-  version: 1
-  editable: false
-  jsonData:
-    httpMethod: GET
-- name: Tempo
-  type: tempo
-  access: proxy
-  orgId: 1
-  url: http://tempo:3200
-  basicAuth: false
-  isDefault: true
-  version: 1
-  editable: false
-  apiVersion: 1
-  uid: tempo
-  jsonData:
-    httpMethod: GET
-    serviceMap:
-      datasourceUid: prometheus
+  - name: Loki
+    type: loki
+    # uid: prometheus
+    access: proxy
+    orgId: 1
+    url: http://loki:3100
+    basicAuth: false
+    isDefault: false
+    version: 1
+    editable: false
+    jsonData:
+      httpMethod: GET
+
+  - name: Prometheus
+    type: prometheus
+    uid: prometheus
+    access: proxy
+    orgId: 1
+    url: http://prometheus:9090
+    basicAuth: false
+    isDefault: false
+    version: 1
+    editable: false
+    jsonData:
+      httpMethod: GET
+
+  # - name: Pyroscope
+  #   type: pyroscope-datasource
+  #   uid: pyroscope
+  #   access: proxy
+  #   orgId: 1
+  #   basicAuth: false
+  #   isDefault: false
+  #   version: 1
+  #   jsonData:
+  #     path: http://pyroscope:4040
+
+  - name: Tempo
+    type: tempo
+    access: proxy
+    orgId: 1
+    url: http://tempo:3200
+    basicAuth: false
+    isDefault: true
+    version: 1
+    editable: false
+    apiVersion: 1
+    uid: tempo
+    jsonData:
+      httpMethod: GET
+      serviceMap:
+        datasourceUid: prometheus

--- a/internal/files/files/grafana/shared/pyroscope-dashboard.json
+++ b/internal/files/files/grafana/shared/pyroscope-dashboard.json
@@ -1,0 +1,2020 @@
+{
+    "__inputs": [ ],
+    "__requires": [ ],
+    "annotations": {
+       "list": [ ]
+    },
+    "editable": "true",
+    "gnetId": null,
+    "graphTooltip": 0,
+    "hideControls": false,
+    "id": null,
+    "links": [ ],
+    "refresh": "",
+    "rows": [
+       {
+          "collapse": false,
+          "collapsed": false,
+          "panels": [
+             {
+                "columns": [ ],
+                "datasource": "$PROMETHEUS_DS",
+                "gridPos": { },
+                "height": 10,
+                "id": 2,
+                "links": [ ],
+                "span": 12,
+                "styles": [
+                   {
+                      "alias": "__name__",
+                      "pattern": "__name__",
+                      "type": "hidden"
+                   },
+                   {
+                      "alias": "Time",
+                      "pattern": "Time",
+                      "type": "hidden"
+                   },
+                   {
+                      "alias": "instance",
+                      "pattern": "instance",
+                      "type": "hidden"
+                   },
+                   {
+                      "alias": "Value",
+                      "pattern": "Value",
+                      "type": "hidden"
+                   },
+                   {
+                      "alias": "job",
+                      "pattern": "job",
+                      "type": "hidden"
+                   },
+                   {
+                      "alias": "use_embedded_assets",
+                      "pattern": "use_embedded_assets",
+                      "type": "hidden"
+                   }
+                ],
+                "targets": [
+                   {
+                      "expr": "pyroscope_build_info{instance=\"$instance\"}",
+                      "format": "table",
+                      "instant": true,
+                      "intervalFactor": 2,
+                      "legendFormat": "",
+                      "refId": "A"
+                   }
+                ],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "",
+                "type": "table"
+             }
+          ],
+          "repeat": null,
+          "repeatIteration": null,
+          "repeatRowId": null,
+          "showTitle": true,
+          "title": "Meta",
+          "titleSize": "h6",
+          "type": "row"
+       },
+       {
+          "collapse": false,
+          "collapsed": false,
+          "panels": [
+             {
+                "aliasColors": { },
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "$PROMETHEUS_DS",
+                "fill": 1,
+                "fillGradient": 0,
+                "gridPos": { },
+                "id": 3,
+                "legend": {
+                   "alignAsTable": false,
+                   "avg": false,
+                   "current": false,
+                   "max": false,
+                   "min": false,
+                   "rightSide": false,
+                   "show": true,
+                   "sideWidth": null,
+                   "total": false,
+                   "values": false
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [ ],
+                "nullPointMode": "null",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "repeat": null,
+                "seriesOverrides": [ ],
+                "spaceLength": 10,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [
+                   {
+                      "expr": "histogram_quantile(0.99,\n  sum(rate(pyroscope_http_request_duration_seconds_bucket{\n    instance=\"$instance\",\n    handler!=\"/metrics\",\n    handler!=\"/healthz\"\n  }[$__rate_interval]))\n  by (le, handler)\n)\n",
+                      "format": "time_series",
+                      "intervalFactor": 2,
+                      "legendFormat": "{{ handler }}",
+                      "refId": "A"
+                   }
+                ],
+                "thresholds": [ ],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "Request Latency P99",
+                "tooltip": {
+                   "shared": true,
+                   "sort": 0,
+                   "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                   "buckets": null,
+                   "mode": "time",
+                   "name": null,
+                   "show": true,
+                   "values": [ ]
+                },
+                "yaxes": [
+                   {
+                      "format": "seconds",
+                      "label": null,
+                      "logBase": 1,
+                      "max": null,
+                      "min": null,
+                      "show": true
+                   },
+                   {
+                      "format": "seconds",
+                      "label": null,
+                      "logBase": 1,
+                      "max": null,
+                      "min": null,
+                      "show": true
+                   }
+                ]
+             },
+             {
+                "aliasColors": { },
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "$PROMETHEUS_DS",
+                "fill": 1,
+                "fillGradient": 0,
+                "gridPos": { },
+                "id": 4,
+                "legend": {
+                   "alignAsTable": false,
+                   "avg": false,
+                   "current": false,
+                   "max": false,
+                   "min": false,
+                   "rightSide": false,
+                   "show": true,
+                   "sideWidth": null,
+                   "total": false,
+                   "values": false
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [ ],
+                "nullPointMode": "null",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "repeat": null,
+                "seriesOverrides": [ ],
+                "spaceLength": 10,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [
+                   {
+                      "expr": "sum(rate(pyroscope_http_request_duration_seconds_count\n{instance=\"$instance\", code=~\"5..\", handler!=\"/metrics\", handler!=\"/healthz\"}[$__rate_interval])) by (handler)\n/\nsum(rate(pyroscope_http_request_duration_seconds_count{instance=\"$instance\", handler!=\"/metrics\", handler!=\"/healthz\"}[$__rate_interval])) by (handler)\n",
+                      "format": "time_series",
+                      "intervalFactor": 2,
+                      "legendFormat": "{{ handler }}",
+                      "refId": "A"
+                   }
+                ],
+                "thresholds": [ ],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "Error Rate",
+                "tooltip": {
+                   "shared": true,
+                   "sort": 0,
+                   "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                   "buckets": null,
+                   "mode": "time",
+                   "name": null,
+                   "show": true,
+                   "values": [ ]
+                },
+                "yaxes": [
+                   {
+                      "format": "short",
+                      "label": null,
+                      "logBase": 1,
+                      "max": null,
+                      "min": null,
+                      "show": true
+                   },
+                   {
+                      "format": "short",
+                      "label": null,
+                      "logBase": 1,
+                      "max": null,
+                      "min": null,
+                      "show": true
+                   }
+                ]
+             },
+             {
+                "aliasColors": { },
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "$PROMETHEUS_DS",
+                "fill": 1,
+                "fillGradient": 0,
+                "gridPos": { },
+                "id": 5,
+                "legend": {
+                   "alignAsTable": false,
+                   "avg": false,
+                   "current": false,
+                   "max": false,
+                   "min": false,
+                   "rightSide": false,
+                   "show": true,
+                   "sideWidth": null,
+                   "total": false,
+                   "values": false
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [ ],
+                "nullPointMode": "null",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "repeat": null,
+                "seriesOverrides": [ ],
+                "spaceLength": 10,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [
+                   {
+                      "expr": "sum(rate(pyroscope_http_request_duration_seconds_count{instance=\"$instance\", handler!=\"/metrics\", handler!=\"/healthz\"}[$__rate_interval])) by (handler)",
+                      "format": "time_series",
+                      "intervalFactor": 2,
+                      "legendFormat": "{{ handler }}",
+                      "refId": "A"
+                   }
+                ],
+                "thresholds": [ ],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "Throughput",
+                "tooltip": {
+                   "shared": true,
+                   "sort": 0,
+                   "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                   "buckets": null,
+                   "mode": "time",
+                   "name": null,
+                   "show": true,
+                   "values": [ ]
+                },
+                "yaxes": [
+                   {
+                      "format": "short",
+                      "label": null,
+                      "logBase": 1,
+                      "max": null,
+                      "min": null,
+                      "show": true
+                   },
+                   {
+                      "format": "short",
+                      "label": null,
+                      "logBase": 1,
+                      "max": null,
+                      "min": null,
+                      "show": true
+                   }
+                ]
+             },
+             {
+                "aliasColors": { },
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "$PROMETHEUS_DS",
+                "fill": 1,
+                "fillGradient": 0,
+                "gridPos": { },
+                "id": 6,
+                "legend": {
+                   "alignAsTable": false,
+                   "avg": false,
+                   "current": false,
+                   "max": false,
+                   "min": false,
+                   "rightSide": false,
+                   "show": true,
+                   "sideWidth": null,
+                   "total": false,
+                   "values": false
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [ ],
+                "nullPointMode": "null",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "repeat": null,
+                "seriesOverrides": [ ],
+                "spaceLength": 10,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [
+                   {
+                      "expr": "histogram_quantile(0.95, sum(rate(pyroscope_http_response_size_bytes_bucket{instance=\"$instance\", handler!=\"/metrics\", handler!=\"/healthz\"}[$__rate_interval])) by (le, handler))",
+                      "format": "time_series",
+                      "intervalFactor": 2,
+                      "legendFormat": "{{ handler }}",
+                      "refId": "A"
+                   }
+                ],
+                "thresholds": [ ],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "Response Size P99",
+                "tooltip": {
+                   "shared": true,
+                   "sort": 0,
+                   "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                   "buckets": null,
+                   "mode": "time",
+                   "name": null,
+                   "show": true,
+                   "values": [ ]
+                },
+                "yaxes": [
+                   {
+                      "format": "bytes",
+                      "label": null,
+                      "logBase": 1,
+                      "max": null,
+                      "min": null,
+                      "show": true
+                   },
+                   {
+                      "format": "bytes",
+                      "label": null,
+                      "logBase": 1,
+                      "max": null,
+                      "min": null,
+                      "show": true
+                   }
+                ]
+             },
+             {
+                "aliasColors": { },
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "$PROMETHEUS_DS",
+                "fill": 1,
+                "fillGradient": 0,
+                "gridPos": { },
+                "id": 7,
+                "legend": {
+                   "alignAsTable": false,
+                   "avg": false,
+                   "current": false,
+                   "max": false,
+                   "min": false,
+                   "rightSide": false,
+                   "show": false,
+                   "sideWidth": null,
+                   "total": false,
+                   "values": false
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [ ],
+                "nullPointMode": "null",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "repeat": null,
+                "seriesOverrides": [ ],
+                "spaceLength": 10,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [
+                   {
+                      "expr": "process_cpu_seconds_total{instance=\"$instance\"}",
+                      "format": "time_series",
+                      "intervalFactor": 2,
+                      "legendFormat": "",
+                      "refId": "A"
+                   }
+                ],
+                "thresholds": [ ],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "CPU Utilization",
+                "tooltip": {
+                   "shared": true,
+                   "sort": 0,
+                   "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                   "buckets": null,
+                   "mode": "time",
+                   "name": null,
+                   "show": true,
+                   "values": [ ]
+                },
+                "yaxes": [
+                   {
+                      "format": "percent",
+                      "label": null,
+                      "logBase": 1,
+                      "max": "100",
+                      "min": "0",
+                      "show": true
+                   },
+                   {
+                      "format": "percent",
+                      "label": null,
+                      "logBase": 1,
+                      "max": "100",
+                      "min": "0",
+                      "show": true
+                   }
+                ]
+             }
+          ],
+          "repeat": null,
+          "repeatIteration": null,
+          "repeatRowId": null,
+          "showTitle": true,
+          "title": "General",
+          "titleSize": "h6",
+          "type": "row"
+       },
+       {
+          "collapse": false,
+          "collapsed": false,
+          "panels": [
+             {
+                "aliasColors": { },
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "$PROMETHEUS_DS",
+                "fill": 1,
+                "fillGradient": 0,
+                "gridPos": { },
+                "id": 8,
+                "legend": {
+                   "alignAsTable": "true",
+                   "avg": false,
+                   "current": "true",
+                   "max": false,
+                   "min": false,
+                   "rightSide": "true",
+                   "show": true,
+                   "sideWidth": null,
+                   "sort": "current",
+                   "sortDesc": true,
+                   "total": false,
+                   "values": "true"
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [ ],
+                "nullPointMode": "null",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "repeat": null,
+                "seriesOverrides": [ ],
+                "spaceLength": 10,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [
+                   {
+                      "expr": "(rate(pyroscope_storage_db_cache_reads_total[$__rate_interval])-\nrate(pyroscope_storage_db_cache_misses_total[$__rate_interval]))\n/\nrate(pyroscope_storage_db_cache_reads_total[$__rate_interval])\n",
+                      "format": "time_series",
+                      "intervalFactor": 2,
+                      "legendFormat": "{{ name }}",
+                      "refId": "A"
+                   }
+                ],
+                "thresholds": [ ],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "Cache Hit Ratio",
+                "tooltip": {
+                   "shared": true,
+                   "sort": 0,
+                   "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                   "buckets": null,
+                   "mode": "time",
+                   "name": null,
+                   "show": true,
+                   "values": [ ]
+                },
+                "yaxes": [
+                   {
+                      "format": "percentunit",
+                      "label": null,
+                      "logBase": 1,
+                      "max": null,
+                      "min": null,
+                      "show": true
+                   },
+                   {
+                      "format": "percentunit",
+                      "label": null,
+                      "logBase": 1,
+                      "max": null,
+                      "min": null,
+                      "show": true
+                   }
+                ]
+             },
+             {
+                "aliasColors": { },
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "$PROMETHEUS_DS",
+                "fill": 1,
+                "fillGradient": 0,
+                "gridPos": { },
+                "id": 9,
+                "legend": {
+                   "alignAsTable": "true",
+                   "avg": false,
+                   "current": "true",
+                   "max": false,
+                   "min": false,
+                   "rightSide": "true",
+                   "show": true,
+                   "sideWidth": null,
+                   "sort": "current",
+                   "sortDesc": true,
+                   "total": false,
+                   "values": "true"
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [ ],
+                "nullPointMode": "null",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "repeat": null,
+                "seriesOverrides": [ ],
+                "spaceLength": 10,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [
+                   {
+                      "expr": "rate(pyroscope_storage_db_cache_write_bytes_sum[$__rate_interval])*-1",
+                      "format": "time_series",
+                      "intervalFactor": 2,
+                      "legendFormat": "Writes - {{name}}",
+                      "refId": "A"
+                   },
+                   {
+                      "expr": "rate(pyroscope_storage_db_cache_read_bytes_sum[$__rate_interval])",
+                      "format": "time_series",
+                      "intervalFactor": 2,
+                      "legendFormat": "Reads - {{name}}",
+                      "refId": "B"
+                   }
+                ],
+                "thresholds": [ ],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "Cache disk IO",
+                "tooltip": {
+                   "shared": true,
+                   "sort": 0,
+                   "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                   "buckets": null,
+                   "mode": "time",
+                   "name": null,
+                   "show": true,
+                   "values": [ ]
+                },
+                "yaxes": [
+                   {
+                      "format": "Bps",
+                      "label": null,
+                      "logBase": 1,
+                      "max": null,
+                      "min": null,
+                      "show": true
+                   },
+                   {
+                      "format": "Bps",
+                      "label": null,
+                      "logBase": 1,
+                      "max": null,
+                      "min": null,
+                      "show": true
+                   }
+                ]
+             },
+             {
+                "aliasColors": { },
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "$PROMETHEUS_DS",
+                "fill": 1,
+                "fillGradient": 0,
+                "gridPos": { },
+                "id": 10,
+                "legend": {
+                   "alignAsTable": false,
+                   "avg": false,
+                   "current": false,
+                   "max": false,
+                   "min": false,
+                   "rightSide": false,
+                   "show": true,
+                   "sideWidth": null,
+                   "total": false,
+                   "values": false
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [ ],
+                "nullPointMode": "null",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "repeat": null,
+                "seriesOverrides": [ ],
+                "spaceLength": 10,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [
+                   {
+                      "expr": "rate(pyroscope_storage_reads_total[$__rate_interval])",
+                      "format": "time_series",
+                      "intervalFactor": 2,
+                      "legendFormat": "Reads",
+                      "refId": "A"
+                   },
+                   {
+                      "expr": "rate(pyroscope_storage_writes_total[$__rate_interval])",
+                      "format": "time_series",
+                      "intervalFactor": 2,
+                      "legendFormat": "Writes",
+                      "refId": "B"
+                   }
+                ],
+                "thresholds": [ ],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "Storage Reads/Writes",
+                "tooltip": {
+                   "shared": true,
+                   "sort": 0,
+                   "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                   "buckets": null,
+                   "mode": "time",
+                   "name": null,
+                   "show": true,
+                   "values": [ ]
+                },
+                "yaxes": [
+                   {
+                      "format": "short",
+                      "label": null,
+                      "logBase": 1,
+                      "max": null,
+                      "min": null,
+                      "show": true
+                   },
+                   {
+                      "format": "short",
+                      "label": null,
+                      "logBase": 1,
+                      "max": null,
+                      "min": null,
+                      "show": true
+                   }
+                ]
+             },
+             {
+                "aliasColors": { },
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "$PROMETHEUS_DS",
+                "fill": 1,
+                "fillGradient": 0,
+                "gridPos": { },
+                "id": 11,
+                "legend": {
+                   "alignAsTable": false,
+                   "avg": false,
+                   "current": false,
+                   "max": false,
+                   "min": false,
+                   "rightSide": false,
+                   "show": true,
+                   "sideWidth": null,
+                   "total": false,
+                   "values": "true"
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [ ],
+                "nullPointMode": "null",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "repeat": null,
+                "seriesOverrides": [ ],
+                "spaceLength": 10,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [
+                   {
+                      "expr": "pyroscope_storage_eviction_task_duration_seconds{quantile=\"0.99\"}",
+                      "format": "time_series",
+                      "intervalFactor": 2,
+                      "legendFormat": "evictions",
+                      "refId": "A"
+                   },
+                   {
+                      "expr": "pyroscope_storage_writeback_task_duration_seconds{quantile=\"0.99\"}",
+                      "format": "time_series",
+                      "intervalFactor": 2,
+                      "legendFormat": "write-back",
+                      "refId": "B"
+                   },
+                   {
+                      "expr": "pyroscope_storage_retention_task_duration_seconds{quantile=\"0.99\"}",
+                      "format": "time_series",
+                      "intervalFactor": 2,
+                      "legendFormat": "retention",
+                      "refId": "C"
+                   }
+                ],
+                "thresholds": [ ],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "Periodic tasks",
+                "tooltip": {
+                   "shared": true,
+                   "sort": 0,
+                   "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                   "buckets": null,
+                   "mode": "time",
+                   "name": null,
+                   "show": true,
+                   "values": [ ]
+                },
+                "yaxes": [
+                   {
+                      "format": "seconds",
+                      "label": null,
+                      "logBase": 2,
+                      "max": null,
+                      "min": null,
+                      "show": true
+                   },
+                   {
+                      "format": "seconds",
+                      "label": null,
+                      "logBase": 1,
+                      "max": null,
+                      "min": null,
+                      "show": true
+                   }
+                ]
+             },
+             {
+                "aliasColors": { },
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "$PROMETHEUS_DS",
+                "fill": 1,
+                "fillGradient": 0,
+                "gridPos": { },
+                "id": 12,
+                "legend": {
+                   "alignAsTable": "true",
+                   "avg": false,
+                   "current": "true",
+                   "max": false,
+                   "min": false,
+                   "rightSide": "true",
+                   "show": true,
+                   "sideWidth": null,
+                   "sort": "current",
+                   "sortDesc": true,
+                   "total": false,
+                   "values": "true"
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [ ],
+                "nullPointMode": "null",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "repeat": null,
+                "seriesOverrides": [ ],
+                "spaceLength": 10,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [
+                   {
+                      "expr": "pyroscope_storage_db_size_bytes",
+                      "format": "time_series",
+                      "intervalFactor": 2,
+                      "legendFormat": "{{ name }}",
+                      "refId": "A"
+                   },
+                   {
+                      "expr": "sum without(name)(pyroscope_storage_db_size_bytes)",
+                      "format": "time_series",
+                      "intervalFactor": 2,
+                      "legendFormat": "total",
+                      "refId": "B"
+                   }
+                ],
+                "thresholds": [ ],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "Disk Usage",
+                "tooltip": {
+                   "shared": true,
+                   "sort": 0,
+                   "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                   "buckets": null,
+                   "mode": "time",
+                   "name": null,
+                   "show": true,
+                   "values": [ ]
+                },
+                "yaxes": [
+                   {
+                      "format": "bytes",
+                      "label": null,
+                      "logBase": 1,
+                      "max": null,
+                      "min": null,
+                      "show": true
+                   },
+                   {
+                      "format": "bytes",
+                      "label": null,
+                      "logBase": 1,
+                      "max": null,
+                      "min": null,
+                      "show": true
+                   }
+                ]
+             },
+             {
+                "aliasColors": { },
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "$PROMETHEUS_DS",
+                "fill": 1,
+                "fillGradient": 0,
+                "gridPos": { },
+                "id": 13,
+                "legend": {
+                   "alignAsTable": "true",
+                   "avg": false,
+                   "current": "true",
+                   "max": false,
+                   "min": false,
+                   "rightSide": "true",
+                   "show": true,
+                   "sideWidth": null,
+                   "sort": "current",
+                   "sortDesc": true,
+                   "total": false,
+                   "values": "true"
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [ ],
+                "nullPointMode": "null",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "repeat": null,
+                "seriesOverrides": [ ],
+                "spaceLength": 10,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [
+                   {
+                      "expr": "pyroscope_storage_db_cache_size",
+                      "format": "time_series",
+                      "intervalFactor": 2,
+                      "legendFormat": "{{ name }}",
+                      "refId": "A"
+                   },
+                   {
+                      "expr": "sum without(name)(pyroscope_storage_db_cache_size)",
+                      "format": "time_series",
+                      "intervalFactor": 2,
+                      "legendFormat": "total",
+                      "refId": "B"
+                   }
+                ],
+                "thresholds": [ ],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "Cache Size (number of items)",
+                "tooltip": {
+                   "shared": true,
+                   "sort": 0,
+                   "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                   "buckets": null,
+                   "mode": "time",
+                   "name": null,
+                   "show": true,
+                   "values": [ ]
+                },
+                "yaxes": [
+                   {
+                      "format": "short",
+                      "label": null,
+                      "logBase": 1,
+                      "max": null,
+                      "min": null,
+                      "show": true
+                   },
+                   {
+                      "format": "short",
+                      "label": null,
+                      "logBase": 1,
+                      "max": null,
+                      "min": null,
+                      "show": true
+                   }
+                ]
+             }
+          ],
+          "repeat": null,
+          "repeatIteration": null,
+          "repeatRowId": null,
+          "showTitle": true,
+          "title": "Storage",
+          "titleSize": "h6",
+          "type": "row"
+       },
+       {
+          "collapse": true,
+          "collapsed": true,
+          "panels": [
+             {
+                "aliasColors": { },
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "$PROMETHEUS_DS",
+                "fill": 1,
+                "fillGradient": 0,
+                "gridPos": { },
+                "id": 14,
+                "legend": {
+                   "alignAsTable": false,
+                   "avg": false,
+                   "current": false,
+                   "max": false,
+                   "min": false,
+                   "rightSide": false,
+                   "show": true,
+                   "sideWidth": null,
+                   "total": false,
+                   "values": false
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [ ],
+                "nullPointMode": "null",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "repeat": null,
+                "seriesOverrides": [ ],
+                "spaceLength": 10,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [
+                   {
+                      "expr": "go_memstats_mspan_inuse_bytes{instance=\"$instance\"}",
+                      "format": "time_series",
+                      "intervalFactor": 2,
+                      "legendFormat": "{{ __name__ }}",
+                      "refId": "A"
+                   },
+                   {
+                      "expr": "go_memstats_mspan_sys_bytes{instance=\"$instance\"}",
+                      "format": "time_series",
+                      "intervalFactor": 2,
+                      "legendFormat": "{{ __name__ }}",
+                      "refId": "B"
+                   },
+                   {
+                      "expr": "go_memstats_mcache_inuse_bytes{instance=\"$instance\"}",
+                      "format": "time_series",
+                      "intervalFactor": 2,
+                      "legendFormat": "{{ __name__ }}",
+                      "refId": "C"
+                   },
+                   {
+                      "expr": "go_memstats_mcache_sys_bytes{instance=\"$instance\"}",
+                      "format": "time_series",
+                      "intervalFactor": 2,
+                      "legendFormat": "{{ __name__ }}",
+                      "refId": "D"
+                   },
+                   {
+                      "expr": "go_memstats_buck_hash_sys_bytes{instance=\"$instance\"}",
+                      "format": "time_series",
+                      "intervalFactor": 2,
+                      "legendFormat": "{{ __name__ }}",
+                      "refId": "E"
+                   },
+                   {
+                      "expr": "go_memstats_gc_sys_bytes{instance=\"$instance\"}",
+                      "format": "time_series",
+                      "intervalFactor": 2,
+                      "legendFormat": "{{ __name__ }}",
+                      "refId": "F"
+                   },
+                   {
+                      "expr": "go_memstats_other_sys_bytes{instance=\"$instance\"}",
+                      "format": "time_series",
+                      "intervalFactor": 2,
+                      "legendFormat": "{{ __name__ }}",
+                      "refId": "G"
+                   },
+                   {
+                      "expr": "go_memstats_next_gc_bytes{instance=\"$instance\"}",
+                      "format": "time_series",
+                      "intervalFactor": 2,
+                      "legendFormat": "{{ __name__ }}",
+                      "refId": "H"
+                   }
+                ],
+                "thresholds": [ ],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "Memory Off-heap",
+                "tooltip": {
+                   "shared": true,
+                   "sort": 0,
+                   "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                   "buckets": null,
+                   "mode": "time",
+                   "name": null,
+                   "show": true,
+                   "values": [ ]
+                },
+                "yaxes": [
+                   {
+                      "format": "bytes",
+                      "label": null,
+                      "logBase": 1,
+                      "max": null,
+                      "min": null,
+                      "show": true
+                   },
+                   {
+                      "format": "bytes",
+                      "label": null,
+                      "logBase": 1,
+                      "max": null,
+                      "min": null,
+                      "show": true
+                   }
+                ]
+             },
+             {
+                "aliasColors": { },
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "$PROMETHEUS_DS",
+                "fill": 1,
+                "fillGradient": 0,
+                "gridPos": { },
+                "id": 15,
+                "legend": {
+                   "alignAsTable": false,
+                   "avg": false,
+                   "current": false,
+                   "max": false,
+                   "min": false,
+                   "rightSide": false,
+                   "show": true,
+                   "sideWidth": null,
+                   "total": false,
+                   "values": false
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [ ],
+                "nullPointMode": "null",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "repeat": null,
+                "seriesOverrides": [ ],
+                "spaceLength": 10,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [
+                   {
+                      "expr": "go_memstats_heap_alloc_bytes{instance=\"$instance\"}",
+                      "format": "time_series",
+                      "intervalFactor": 2,
+                      "legendFormat": "{{ __name__ }}",
+                      "refId": "A"
+                   },
+                   {
+                      "expr": "go_memstats_heap_sys_bytes{instance=\"$instance\"}",
+                      "format": "time_series",
+                      "intervalFactor": 2,
+                      "legendFormat": "{{ __name__ }}",
+                      "refId": "B"
+                   },
+                   {
+                      "expr": "go_memstats_heap_idle_bytes{instance=\"$instance\"}",
+                      "format": "time_series",
+                      "intervalFactor": 2,
+                      "legendFormat": "{{ __name__ }}",
+                      "refId": "C"
+                   },
+                   {
+                      "expr": "go_memstats_heap_inuse_bytes{instance=\"$instance\"}",
+                      "format": "time_series",
+                      "intervalFactor": 2,
+                      "legendFormat": "{{ __name__ }}",
+                      "refId": "D"
+                   },
+                   {
+                      "expr": "go_memstats_heap_released_bytes{instance=\"$instance\"}",
+                      "format": "time_series",
+                      "intervalFactor": 2,
+                      "legendFormat": "{{ __name__ }}",
+                      "refId": "E"
+                   }
+                ],
+                "thresholds": [ ],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "Memory In Heap",
+                "tooltip": {
+                   "shared": true,
+                   "sort": 0,
+                   "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                   "buckets": null,
+                   "mode": "time",
+                   "name": null,
+                   "show": true,
+                   "values": [ ]
+                },
+                "yaxes": [
+                   {
+                      "format": "bytes",
+                      "label": null,
+                      "logBase": 1,
+                      "max": null,
+                      "min": null,
+                      "show": true
+                   },
+                   {
+                      "format": "bytes",
+                      "label": null,
+                      "logBase": 1,
+                      "max": null,
+                      "min": null,
+                      "show": true
+                   }
+                ]
+             },
+             {
+                "aliasColors": { },
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "$PROMETHEUS_DS",
+                "fill": 1,
+                "fillGradient": 0,
+                "gridPos": { },
+                "id": 16,
+                "legend": {
+                   "alignAsTable": false,
+                   "avg": false,
+                   "current": false,
+                   "max": false,
+                   "min": false,
+                   "rightSide": false,
+                   "show": true,
+                   "sideWidth": null,
+                   "total": false,
+                   "values": false
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [ ],
+                "nullPointMode": "null",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "repeat": null,
+                "seriesOverrides": [ ],
+                "spaceLength": 10,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [
+                   {
+                      "expr": "go_memstats_stack_inuse_bytes{instance=\"$instance\"}",
+                      "format": "time_series",
+                      "intervalFactor": 2,
+                      "legendFormat": "{{ __name__ }}",
+                      "refId": "A"
+                   },
+                   {
+                      "expr": "go_memstats_stack_sys_bytes{instance=\"$instance\"}",
+                      "format": "time_series",
+                      "intervalFactor": 2,
+                      "legendFormat": "{{ __name__ }}",
+                      "refId": "B"
+                   }
+                ],
+                "thresholds": [ ],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "Memory In Stack",
+                "tooltip": {
+                   "shared": true,
+                   "sort": 0,
+                   "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                   "buckets": null,
+                   "mode": "time",
+                   "name": null,
+                   "show": true,
+                   "values": [ ]
+                },
+                "yaxes": [
+                   {
+                      "format": "decbytes",
+                      "label": null,
+                      "logBase": 1,
+                      "max": null,
+                      "min": null,
+                      "show": true
+                   },
+                   {
+                      "format": "decbytes",
+                      "label": null,
+                      "logBase": 1,
+                      "max": null,
+                      "min": null,
+                      "show": true
+                   }
+                ]
+             },
+             {
+                "aliasColors": { },
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "$PROMETHEUS_DS",
+                "fill": 1,
+                "fillGradient": 0,
+                "gridPos": { },
+                "id": 17,
+                "legend": {
+                   "alignAsTable": false,
+                   "avg": false,
+                   "current": false,
+                   "max": false,
+                   "min": false,
+                   "rightSide": false,
+                   "show": true,
+                   "sideWidth": null,
+                   "total": false,
+                   "values": false
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [ ],
+                "nullPointMode": "null",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "repeat": null,
+                "seriesOverrides": [ ],
+                "spaceLength": 10,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [
+                   {
+                      "expr": "go_memstats_sys_bytes{instance=\"$instance\"}",
+                      "format": "time_series",
+                      "intervalFactor": 2,
+                      "legendFormat": "{{ __name__ }}",
+                      "refId": "A"
+                   }
+                ],
+                "thresholds": [ ],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "Total Used Memory",
+                "tooltip": {
+                   "shared": true,
+                   "sort": 0,
+                   "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                   "buckets": null,
+                   "mode": "time",
+                   "name": null,
+                   "show": true,
+                   "values": [ ]
+                },
+                "yaxes": [
+                   {
+                      "format": "decbytes",
+                      "label": null,
+                      "logBase": 1,
+                      "max": null,
+                      "min": null,
+                      "show": true
+                   },
+                   {
+                      "format": "decbytes",
+                      "label": null,
+                      "logBase": 1,
+                      "max": null,
+                      "min": null,
+                      "show": true
+                   }
+                ]
+             },
+             {
+                "aliasColors": { },
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "$PROMETHEUS_DS",
+                "fill": 1,
+                "fillGradient": 0,
+                "gridPos": { },
+                "id": 18,
+                "legend": {
+                   "alignAsTable": false,
+                   "avg": false,
+                   "current": false,
+                   "max": false,
+                   "min": false,
+                   "rightSide": false,
+                   "show": false,
+                   "sideWidth": null,
+                   "total": false,
+                   "values": false
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [ ],
+                "nullPointMode": "null",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "repeat": null,
+                "seriesOverrides": [ ],
+                "spaceLength": 10,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [
+                   {
+                      "expr": "go_memstats_mallocs_total{instance=\"$instance\"} - go_memstats_frees_total{instance=\"$instance\"}",
+                      "format": "time_series",
+                      "intervalFactor": 2,
+                      "legendFormat": "",
+                      "refId": "A"
+                   }
+                ],
+                "thresholds": [ ],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "Number of Live Objects",
+                "tooltip": {
+                   "shared": true,
+                   "sort": 0,
+                   "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                   "buckets": null,
+                   "mode": "time",
+                   "name": null,
+                   "show": true,
+                   "values": [ ]
+                },
+                "yaxes": [
+                   {
+                      "format": "short",
+                      "label": null,
+                      "logBase": 1,
+                      "max": null,
+                      "min": null,
+                      "show": true
+                   },
+                   {
+                      "format": "short",
+                      "label": null,
+                      "logBase": 1,
+                      "max": null,
+                      "min": null,
+                      "show": true
+                   }
+                ]
+             },
+             {
+                "aliasColors": { },
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "$PROMETHEUS_DS",
+                "fill": 1,
+                "fillGradient": 0,
+                "gridPos": { },
+                "id": 19,
+                "legend": {
+                   "alignAsTable": false,
+                   "avg": false,
+                   "current": false,
+                   "max": false,
+                   "min": false,
+                   "rightSide": false,
+                   "show": false,
+                   "sideWidth": null,
+                   "total": false,
+                   "values": false
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [ ],
+                "nullPointMode": "null",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "repeat": null,
+                "seriesOverrides": [ ],
+                "spaceLength": 10,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [
+                   {
+                      "expr": "rate(go_memstats_mallocs_total{instance=\"$instance\"}[$__rate_interval])",
+                      "format": "time_series",
+                      "intervalFactor": 2,
+                      "legendFormat": "",
+                      "refId": "A"
+                   }
+                ],
+                "thresholds": [ ],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "Rate of Objects Allocated",
+                "tooltip": {
+                   "shared": true,
+                   "sort": 0,
+                   "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                   "buckets": null,
+                   "mode": "time",
+                   "name": null,
+                   "show": true,
+                   "values": [ ]
+                },
+                "yaxes": [
+                   {
+                      "format": "short",
+                      "label": null,
+                      "logBase": 1,
+                      "max": null,
+                      "min": null,
+                      "show": true
+                   },
+                   {
+                      "format": "short",
+                      "label": null,
+                      "logBase": 1,
+                      "max": null,
+                      "min": null,
+                      "show": true
+                   }
+                ]
+             },
+             {
+                "aliasColors": { },
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "$PROMETHEUS_DS",
+                "fill": 1,
+                "fillGradient": 0,
+                "gridPos": { },
+                "id": 20,
+                "legend": {
+                   "alignAsTable": false,
+                   "avg": false,
+                   "current": false,
+                   "max": false,
+                   "min": false,
+                   "rightSide": false,
+                   "show": false,
+                   "sideWidth": null,
+                   "total": false,
+                   "values": false
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [ ],
+                "nullPointMode": "null",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "repeat": null,
+                "seriesOverrides": [ ],
+                "spaceLength": 10,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [
+                   {
+                      "expr": "rate(go_memstats_alloc_bytes_total{instance=\"$instance\"}[$__rate_interval])",
+                      "format": "time_series",
+                      "intervalFactor": 2,
+                      "legendFormat": "",
+                      "refId": "A"
+                   }
+                ],
+                "thresholds": [ ],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "Rates of Allocation",
+                "tooltip": {
+                   "shared": true,
+                   "sort": 0,
+                   "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                   "buckets": null,
+                   "mode": "time",
+                   "name": null,
+                   "show": true,
+                   "values": [ ]
+                },
+                "yaxes": [
+                   {
+                      "format": "Bps",
+                      "label": null,
+                      "logBase": 1,
+                      "max": null,
+                      "min": null,
+                      "show": true
+                   },
+                   {
+                      "format": "Bps",
+                      "label": null,
+                      "logBase": 1,
+                      "max": null,
+                      "min": null,
+                      "show": true
+                   }
+                ]
+             },
+             {
+                "aliasColors": { },
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "$PROMETHEUS_DS",
+                "fill": 1,
+                "fillGradient": 0,
+                "gridPos": { },
+                "id": 21,
+                "legend": {
+                   "alignAsTable": false,
+                   "avg": false,
+                   "current": false,
+                   "max": false,
+                   "min": false,
+                   "rightSide": false,
+                   "show": false,
+                   "sideWidth": null,
+                   "total": false,
+                   "values": false
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [ ],
+                "nullPointMode": "null",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "repeat": null,
+                "seriesOverrides": [ ],
+                "spaceLength": 10,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [
+                   {
+                      "expr": "go_goroutines{instance=\"$instance\"}",
+                      "format": "time_series",
+                      "intervalFactor": 2,
+                      "legendFormat": "",
+                      "refId": "A"
+                   }
+                ],
+                "thresholds": [ ],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "Goroutines",
+                "tooltip": {
+                   "shared": true,
+                   "sort": 0,
+                   "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                   "buckets": null,
+                   "mode": "time",
+                   "name": null,
+                   "show": true,
+                   "values": [ ]
+                },
+                "yaxes": [
+                   {
+                      "format": "short",
+                      "label": null,
+                      "logBase": 1,
+                      "max": null,
+                      "min": null,
+                      "show": true
+                   },
+                   {
+                      "format": "short",
+                      "label": null,
+                      "logBase": 1,
+                      "max": null,
+                      "min": null,
+                      "show": true
+                   }
+                ]
+             },
+             {
+                "aliasColors": { },
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "$PROMETHEUS_DS",
+                "fill": 1,
+                "fillGradient": 0,
+                "gridPos": { },
+                "id": 22,
+                "legend": {
+                   "alignAsTable": false,
+                   "avg": false,
+                   "current": false,
+                   "max": false,
+                   "min": false,
+                   "rightSide": false,
+                   "show": false,
+                   "sideWidth": null,
+                   "total": false,
+                   "values": false
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [ ],
+                "nullPointMode": "null",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "repeat": null,
+                "seriesOverrides": [ ],
+                "spaceLength": 10,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [
+                   {
+                      "expr": "go_gc_duration_seconds{instance=\"$instance\"}",
+                      "format": "time_series",
+                      "intervalFactor": 2,
+                      "legendFormat": "",
+                      "refId": "A"
+                   }
+                ],
+                "thresholds": [ ],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "GC duration quantile",
+                "tooltip": {
+                   "shared": true,
+                   "sort": 0,
+                   "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                   "buckets": null,
+                   "mode": "time",
+                   "name": null,
+                   "show": true,
+                   "values": [ ]
+                },
+                "yaxes": [
+                   {
+                      "format": "short",
+                      "label": null,
+                      "logBase": 1,
+                      "max": null,
+                      "min": null,
+                      "show": true
+                   },
+                   {
+                      "format": "short",
+                      "label": null,
+                      "logBase": 1,
+                      "max": null,
+                      "min": null,
+                      "show": true
+                   }
+                ]
+             },
+             {
+                "aliasColors": { },
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "$PROMETHEUS_DS",
+                "fill": 1,
+                "fillGradient": 0,
+                "gridPos": { },
+                "id": 23,
+                "legend": {
+                   "alignAsTable": false,
+                   "avg": false,
+                   "current": false,
+                   "max": false,
+                   "min": false,
+                   "rightSide": false,
+                   "show": true,
+                   "sideWidth": null,
+                   "total": false,
+                   "values": false
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [ ],
+                "nullPointMode": "null",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "repeat": null,
+                "seriesOverrides": [ ],
+                "spaceLength": 10,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [
+                   {
+                      "expr": "process_open_fds{instance=\"$instance\"}",
+                      "format": "time_series",
+                      "intervalFactor": 2,
+                      "legendFormat": "{{ __name__ }}",
+                      "refId": "A"
+                   },
+                   {
+                      "expr": "process_max_fds{instance=\"$instance\"}",
+                      "format": "time_series",
+                      "intervalFactor": 2,
+                      "legendFormat": "{{ __name__ }}",
+                      "refId": "B"
+                   }
+                ],
+                "thresholds": [ ],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "File descriptors",
+                "tooltip": {
+                   "shared": true,
+                   "sort": 0,
+                   "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                   "buckets": null,
+                   "mode": "time",
+                   "name": null,
+                   "show": true,
+                   "values": [ ]
+                },
+                "yaxes": [
+                   {
+                      "format": "short",
+                      "label": null,
+                      "logBase": 1,
+                      "max": null,
+                      "min": null,
+                      "show": true
+                   },
+                   {
+                      "format": "short",
+                      "label": null,
+                      "logBase": 1,
+                      "max": null,
+                      "min": null,
+                      "show": true
+                   }
+                ]
+             }
+          ],
+          "repeat": null,
+          "repeatIteration": null,
+          "repeatRowId": null,
+          "showTitle": true,
+          "title": "Go",
+          "titleSize": "h6",
+          "type": "row"
+       }
+    ],
+    "schemaVersion": 14,
+    "style": "dark",
+    "tags": [
+       "pyroscope"
+    ],
+    "templating": {
+       "list": [
+          {
+             "current": {
+                "text": "prometheus",
+                "value": "prometheus"
+             },
+             "hide": 2,
+             "label": null,
+             "name": "PROMETHEUS_DS",
+             "options": [ ],
+             "query": "prometheus",
+             "refresh": 1,
+             "regex": "",
+             "type": "datasource"
+          },
+          {
+             "allValue": null,
+             "current": { },
+             "datasource": "$PROMETHEUS_DS",
+             "hide": 0,
+             "includeAll": false,
+             "label": "instance",
+             "multi": false,
+             "name": "instance",
+             "options": [ ],
+             "query": "label_values(pyroscope_build_info, instance)",
+             "refresh": 2,
+             "regex": "",
+             "sort": 0,
+             "tagValuesQuery": "",
+             "tags": [ ],
+             "tagsQuery": "",
+             "type": "query",
+             "useTags": false
+          }
+       ]
+    },
+    "time": {
+       "from": "now-1h",
+       "to": "now"
+    },
+    "timepicker": {
+       "refresh_intervals": [
+          "5s",
+          "10s",
+          "30s",
+          "1m",
+          "5m",
+          "15m",
+          "30m",
+          "1h",
+          "2h",
+          "1d"
+       ],
+       "time_options": [
+          "5m",
+          "15m",
+          "1h",
+          "6h",
+          "12h",
+          "24h",
+          "2d",
+          "7d",
+          "30d"
+       ]
+    },
+    "timezone": "browser",
+    "title": "Pyroscope Server",
+    "uid": "tsWRL6ReZQkirFirmyvnWX1akHXJeHT8I8emjGJo",
+    "version": 0
+ }

--- a/internal/files/files/grafana/shared/pyroscope/grafana-provisioning/main.yml
+++ b/internal/files/files/grafana/shared/pyroscope/grafana-provisioning/main.yml
@@ -1,0 +1,8 @@
+apiVersion: 1
+
+providers:
+  - name: dashboards
+    type: file
+    updateIntervalSeconds: 5
+    options:
+      path: /etc/grafana/provisioning/dashboards

--- a/internal/files/files/grafana/shared/pyroscope/grafana-provisioning/server-prometheus.json
+++ b/internal/files/files/grafana/shared/pyroscope/grafana-provisioning/server-prometheus.json
@@ -1,0 +1,1459 @@
+{
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": "Prometheus",
+          "enable": true,
+          "expr": "changes(benchmark[5s]) > 0",
+          "hide": true,
+          "iconColor": "rgba(87, 148, 242, 0.24)",
+          "limit": 100,
+          "name": "Annotations & Alerts",
+          "showIn": 0,
+          "step": "5s",
+          "titleFormat": "start/stop",
+          "type": "dashboard"
+        }
+      ]
+    },
+    "editable": true,
+    "gnetId": null,
+    "graphTooltip": 1,
+    "links": [],
+    "panels": [
+      {
+        "datasource": null,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 0
+        },
+        "id": 26,
+        "targets": [
+          {
+            "queryType": "randomWalk",
+            "refId": "A"
+          }
+        ],
+        "title": "CPU",
+        "type": "row"
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "Prometheus",
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 8,
+          "w": 8,
+          "x": 0,
+          "y": 1
+        },
+        "hiddenSeries": false,
+        "id": 3,
+        "interval": "1",
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "null",
+        "options": {
+          "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.1.1",
+        "pointradius": 5,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "exemplar": true,
+            "expr": "cpu_utilization{}",
+            "interval": "",
+            "legendFormat": "{{__name__}}",
+            "queryType": "randomWalk",
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "CPU Utilization",
+        "tooltip": {
+          "shared": true,
+          "sort": 2,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "$$hashKey": "object:81",
+            "format": "percent",
+            "label": null,
+            "logBase": 1,
+            "max": "100",
+            "min": "0",
+            "show": true
+          },
+          {
+            "$$hashKey": "object:82",
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "Prometheus",
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 8,
+          "w": 8,
+          "x": 8,
+          "y": 1
+        },
+        "hiddenSeries": false,
+        "id": 10,
+        "interval": "1",
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "null",
+        "options": {
+          "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.1.1",
+        "pointradius": 5,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "exemplar": true,
+            "expr": "{__name__=~\"go_goroutines\", instance=\"pyroscope:4040\"}",
+            "interval": "",
+            "legendFormat": "{{__name__}}",
+            "queryType": "randomWalk",
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Goroutines",
+        "tooltip": {
+          "shared": true,
+          "sort": 2,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "$$hashKey": "object:42",
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": "0",
+            "show": true
+          },
+          {
+            "$$hashKey": "object:43",
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "Prometheus",
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 8,
+          "w": 8,
+          "x": 16,
+          "y": 1
+        },
+        "hiddenSeries": false,
+        "id": 29,
+        "interval": "1",
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "null",
+        "options": {
+          "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.1.1",
+        "pointradius": 5,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "exemplar": true,
+            "expr": "rate(storage_reads_total{}[1m])",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "reads",
+            "queryType": "randomWalk",
+            "refId": "A"
+          },
+          {
+            "exemplar": true,
+            "expr": "rate(storage_writes_total{}[1m])",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "writes",
+            "queryType": "randomWalk",
+            "refId": "B"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Throughput",
+        "tooltip": {
+          "shared": true,
+          "sort": 2,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "$$hashKey": "object:42",
+            "format": "reqps",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": "0",
+            "show": true
+          },
+          {
+            "$$hashKey": "object:43",
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "collapsed": false,
+        "datasource": null,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 9
+        },
+        "id": 24,
+        "panels": [],
+        "title": "Memory",
+        "type": "row"
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "Prometheus",
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 8,
+          "w": 8,
+          "x": 0,
+          "y": 10
+        },
+        "hiddenSeries": false,
+        "id": 6,
+        "interval": "1",
+        "legend": {
+          "alignAsTable": true,
+          "avg": false,
+          "current": true,
+          "max": false,
+          "min": false,
+          "rightSide": true,
+          "show": true,
+          "sort": "current",
+          "sortDesc": true,
+          "total": false,
+          "values": true
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "null",
+        "options": {
+          "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.1.1",
+        "pointradius": 5,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "exemplar": true,
+            "expr": "{__name__=~\"go_memstats_.+bytes\", instance=\"pyroscope:4040\"}",
+            "interval": "",
+            "legendFormat": "{{__name__}}",
+            "queryType": "randomWalk",
+            "refId": "A"
+          },
+          {
+            "exemplar": true,
+            "expr": "evictions_total_bytes{}",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "RAM total",
+            "queryType": "randomWalk",
+            "refId": "B"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Memory",
+        "tooltip": {
+          "shared": true,
+          "sort": 2,
+          "value_type": "individual"
+        },
+        "transformations": [
+          {
+            "id": "renameByRegex",
+            "options": {
+              "regex": "go_memstats_(.*)_bytes",
+              "renamePattern": "$1"
+            }
+          }
+        ],
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "$$hashKey": "object:123",
+            "format": "bytes",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": "0",
+            "show": true
+          },
+          {
+            "$$hashKey": "object:124",
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "Prometheus",
+        "description": "Number of objects in cache",
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 8,
+          "w": 8,
+          "x": 8,
+          "y": 10
+        },
+        "hiddenSeries": false,
+        "id": 1,
+        "interval": "1",
+        "legend": {
+          "alignAsTable": true,
+          "avg": false,
+          "current": true,
+          "max": false,
+          "min": false,
+          "rightSide": true,
+          "show": true,
+          "sort": "current",
+          "sortDesc": true,
+          "total": false,
+          "values": true
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "null",
+        "options": {
+          "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.1.1",
+        "pointradius": 5,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "exemplar": true,
+            "expr": "{__name__=~\"cache_.+_size\"}",
+            "instant": false,
+            "interval": "",
+            "legendFormat": "{{__name__}}",
+            "queryType": "randomWalk",
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Cache Size",
+        "tooltip": {
+          "shared": true,
+          "sort": 2,
+          "value_type": "individual"
+        },
+        "transformations": [
+          {
+            "id": "renameByRegex",
+            "options": {
+              "regex": "cache_(.*)_size",
+              "renamePattern": "$1"
+            }
+          }
+        ],
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "$$hashKey": "object:560",
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": "0",
+            "show": true
+          },
+          {
+            "$$hashKey": "object:561",
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "Prometheus",
+        "description": "",
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 8,
+          "w": 8,
+          "x": 16,
+          "y": 10
+        },
+        "hiddenSeries": false,
+        "id": 15,
+        "interval": "1",
+        "legend": {
+          "alignAsTable": true,
+          "avg": false,
+          "current": true,
+          "max": false,
+          "min": false,
+          "rightSide": true,
+          "show": true,
+          "sort": "current",
+          "sortDesc": true,
+          "total": false,
+          "values": true
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "null",
+        "options": {
+          "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.1.1",
+        "pointradius": 5,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "exemplar": true,
+            "expr": "cache_dicts_hit / (cache_dicts_hit+cache_dicts_miss)",
+            "instant": false,
+            "interval": "",
+            "legendFormat": "cache_dicts_hit_rate",
+            "queryType": "randomWalk",
+            "refId": "A"
+          },
+          {
+            "exemplar": true,
+            "expr": "cache_trees_hit / (cache_trees_hit+cache_trees_miss)",
+            "hide": false,
+            "instant": false,
+            "interval": "",
+            "legendFormat": "cache_trees_hit_rate",
+            "queryType": "randomWalk",
+            "refId": "B"
+          },
+          {
+            "exemplar": true,
+            "expr": "cache_segments_hit / (cache_segments_hit+cache_segments_miss)",
+            "hide": false,
+            "instant": false,
+            "interval": "",
+            "legendFormat": "cache_segments_hit_rate",
+            "queryType": "randomWalk",
+            "refId": "C"
+          },
+          {
+            "exemplar": true,
+            "expr": "cache_dimensions_hit / (cache_dimensions_hit+cache_dimensions_miss)",
+            "hide": false,
+            "instant": false,
+            "interval": "",
+            "legendFormat": "cache_dimensions_hit_rate",
+            "queryType": "randomWalk",
+            "refId": "D"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Cache Hit Ratios",
+        "tooltip": {
+          "shared": true,
+          "sort": 2,
+          "value_type": "individual"
+        },
+        "transformations": [
+          {
+            "id": "renameByRegex",
+            "options": {
+              "regex": "cache_(.*)_hit_rate",
+              "renamePattern": "$1"
+            }
+          }
+        ],
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "$$hashKey": "object:560",
+            "format": "percentunit",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": "0",
+            "show": true
+          },
+          {
+            "$$hashKey": "object:561",
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "Prometheus",
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 8,
+          "w": 8,
+          "x": 0,
+          "y": 18
+        },
+        "hiddenSeries": false,
+        "id": 12,
+        "interval": "1",
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "null",
+        "options": {
+          "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.1.1",
+        "pointradius": 5,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [
+          {
+            "alias": "evictions",
+            "yaxis": 2
+          },
+          {
+            "alias": "evictions_count",
+            "yaxis": 2
+          }
+        ],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "exemplar": true,
+            "expr": "{__name__=~\"evictions_timer\", instance=\"pyroscope:4040\"}",
+            "interval": "",
+            "legendFormat": "{{__name__}}",
+            "queryType": "randomWalk",
+            "refId": "A"
+          },
+          {
+            "exemplar": true,
+            "expr": "{__name__=~\"evictions_count\", instance=\"pyroscope:4040\"}",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "{{__name__}}",
+            "queryType": "randomWalk",
+            "refId": "B"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Cache Evictions Timer",
+        "tooltip": {
+          "shared": true,
+          "sort": 2,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "$$hashKey": "object:42",
+            "format": "ns",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": "0",
+            "show": true
+          },
+          {
+            "$$hashKey": "object:43",
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "Prometheus",
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 8,
+          "w": 8,
+          "x": 8,
+          "y": 18
+        },
+        "hiddenSeries": false,
+        "id": 20,
+        "interval": "1",
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "null",
+        "options": {
+          "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.1.1",
+        "pointradius": 5,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [
+          {
+            "alias": "evictions",
+            "yaxis": 2
+          },
+          {
+            "alias": "write_back_count",
+            "yaxis": 2
+          }
+        ],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "exemplar": true,
+            "expr": "{__name__=~\"write_back_timer\", instance=\"pyroscope:4040\"}",
+            "interval": "",
+            "legendFormat": "{{__name__}}",
+            "queryType": "randomWalk",
+            "refId": "A"
+          },
+          {
+            "exemplar": true,
+            "expr": "{__name__=~\"write_back_count\", instance=\"pyroscope:4040\"}",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "{{__name__}}",
+            "queryType": "randomWalk",
+            "refId": "B"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Cache Write Back Timer",
+        "tooltip": {
+          "shared": true,
+          "sort": 2,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "$$hashKey": "object:42",
+            "format": "ns",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": "0",
+            "show": true
+          },
+          {
+            "$$hashKey": "object:43",
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "datasource": null,
+        "gridPos": {
+          "h": 8,
+          "w": 8,
+          "x": 16,
+          "y": 18
+        },
+        "id": 28,
+        "options": {
+          "content": "<p style=\"text-align: left; font-weight: bold;\">\n<<< Evictions & Write Back\n</p>\n\nCache objects have two ways of getting persisted:\n* via evictions when there's memory pressure\n* via write-back mechanism that's continiuosly saving data on disk",
+          "mode": "markdown"
+        },
+        "pluginVersion": "8.1.1",
+        "targets": [
+          {
+            "queryType": "randomWalk",
+            "refId": "A"
+          }
+        ],
+        "timeFrom": null,
+        "timeShift": null,
+        "transparent": true,
+        "type": "text"
+      },
+      {
+        "collapsed": false,
+        "datasource": null,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 26
+        },
+        "id": 22,
+        "panels": [],
+        "targets": [
+          {
+            "queryType": "randomWalk",
+            "refId": "A"
+          }
+        ],
+        "title": "Storage",
+        "type": "row"
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "Prometheus",
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 8,
+          "w": 8,
+          "x": 0,
+          "y": 27
+        },
+        "hiddenSeries": false,
+        "id": 2,
+        "interval": "1",
+        "legend": {
+          "alignAsTable": true,
+          "avg": false,
+          "current": true,
+          "max": false,
+          "min": false,
+          "rightSide": true,
+          "show": true,
+          "sort": "current",
+          "sortDesc": true,
+          "total": false,
+          "values": true
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "null",
+        "options": {
+          "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.1.1",
+        "pointradius": 5,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "exemplar": true,
+            "expr": "{__name__=~\"disk_.+\"}",
+            "interval": "",
+            "legendFormat": "{{__name__}}",
+            "queryType": "randomWalk",
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Badger Space Breakdown",
+        "tooltip": {
+          "shared": true,
+          "sort": 2,
+          "value_type": "individual"
+        },
+        "transformations": [
+          {
+            "id": "renameByRegex",
+            "options": {
+              "regex": "disk_(.*)",
+              "renamePattern": "$1"
+            }
+          }
+        ],
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "$$hashKey": "object:74",
+            "format": "bytes",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": "0",
+            "show": true
+          },
+          {
+            "$$hashKey": "object:75",
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "Prometheus",
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 8,
+          "w": 5,
+          "x": 8,
+          "y": 27
+        },
+        "hiddenSeries": false,
+        "id": 17,
+        "interval": "1",
+        "legend": {
+          "alignAsTable": true,
+          "avg": false,
+          "current": true,
+          "max": false,
+          "min": false,
+          "rightSide": true,
+          "show": true,
+          "sort": "current",
+          "sortDesc": true,
+          "total": false,
+          "values": true
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "null",
+        "options": {
+          "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.1.1",
+        "pointradius": 5,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "exemplar": true,
+            "expr": "{__name__=~\"storage_.+_read\"}",
+            "interval": "",
+            "legendFormat": "{{__name__}}",
+            "queryType": "randomWalk",
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Badger Reads",
+        "tooltip": {
+          "shared": true,
+          "sort": 2,
+          "value_type": "individual"
+        },
+        "transformations": [
+          {
+            "id": "renameByRegex",
+            "options": {
+              "regex": "storage_(.*)_read",
+              "renamePattern": "$1"
+            }
+          }
+        ],
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "$$hashKey": "object:66",
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": "0",
+            "show": true
+          },
+          {
+            "$$hashKey": "object:67",
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "Prometheus",
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 8,
+          "w": 5,
+          "x": 13,
+          "y": 27
+        },
+        "hiddenSeries": false,
+        "id": 18,
+        "interval": "1",
+        "legend": {
+          "alignAsTable": true,
+          "avg": false,
+          "current": true,
+          "max": false,
+          "min": false,
+          "rightSide": true,
+          "show": true,
+          "sort": "current",
+          "sortDesc": true,
+          "total": false,
+          "values": true
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "null",
+        "options": {
+          "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.1.1",
+        "pointradius": 5,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "exemplar": true,
+            "expr": "{__name__=~\"storage_.+_write\"}",
+            "interval": "",
+            "legendFormat": "{{__name__}}",
+            "queryType": "randomWalk",
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Badger Writes",
+        "tooltip": {
+          "shared": true,
+          "sort": 2,
+          "value_type": "individual"
+        },
+        "transformations": [
+          {
+            "id": "renameByRegex",
+            "options": {
+              "regex": "storage_(.*)_write",
+              "renamePattern": "$1"
+            }
+          }
+        ],
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "$$hashKey": "object:66",
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": "0",
+            "show": true
+          },
+          {
+            "$$hashKey": "object:67",
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "Prometheus",
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 8,
+          "w": 5,
+          "x": 18,
+          "y": 27
+        },
+        "hiddenSeries": false,
+        "id": 14,
+        "interval": "1",
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "null",
+        "options": {
+          "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.1.1",
+        "pointradius": 5,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [
+          {
+            "alias": "evictions_used_perc",
+            "yaxis": 1
+          },
+          {
+            "alias": "retention_count",
+            "yaxis": 2
+          }
+        ],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "exemplar": true,
+            "expr": "retention_timer",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "{{__name__}}",
+            "queryType": "randomWalk",
+            "refId": "D"
+          },
+          {
+            "exemplar": true,
+            "expr": "retention_count",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "{{__name__}}",
+            "queryType": "randomWalk",
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Retention",
+        "tooltip": {
+          "shared": true,
+          "sort": 2,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "$$hashKey": "object:42",
+            "format": "ns",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": "0",
+            "show": true
+          },
+          {
+            "$$hashKey": "object:43",
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": "0",
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      }
+    ],
+    "refresh": "",
+    "schemaVersion": 30,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+      "list": []
+    },
+    "time": {
+      "from": "now-30m",
+      "to": "now"
+    },
+    "timepicker": {
+      "refresh_intervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "time_options": ["5m", "15m", "1h", "6h", "12h", "24h", "2d", "7d", "30d"]
+    },
+    "timezone": "browser",
+    "title": "Pyroscope Server (Prometheus)",
+    "uid": "65gjqY3Mk",
+    "version": 25
+  }

--- a/internal/files/files/grafana/shared/pyroscope/grafana-provisioning/server-pyroscope.json
+++ b/internal/files/files/grafana/shared/pyroscope/grafana-provisioning/server-pyroscope.json
@@ -1,0 +1,153 @@
+{
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": "-- Grafana --",
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "target": {
+            "limit": 100,
+            "matchAny": false,
+            "tags": [],
+            "type": "dashboard"
+          },
+          "type": "dashboard"
+        }
+      ]
+    },
+    "editable": true,
+    "gnetId": null,
+    "graphTooltip": 0,
+    "id": 3,
+    "links": [],
+    "panels": [
+      {
+        "datasource": "Pyroscope",
+        "gridPos": {
+          "h": 6,
+          "w": 24,
+          "x": 0,
+          "y": 0
+        },
+        "id": 2,
+        "targets": [
+          {
+            "format": "json",
+            "from": "now-1h",
+            "name": "pyroscope.server.cpu",
+            "queryType": "randomWalk",
+            "refId": "A",
+            "until": "now"
+          }
+        ],
+        "title": "pyroscope.server.cpu",
+        "type": "pyroscope-panel"
+      },
+      {
+        "datasource": "Pyroscope",
+        "gridPos": {
+          "h": 7,
+          "w": 24,
+          "x": 0,
+          "y": 6
+        },
+        "id": 5,
+        "targets": [
+          {
+            "format": "json",
+            "from": "now-1h",
+            "name": "pyroscope.server.alloc_objects",
+            "queryType": "randomWalk",
+            "refId": "A",
+            "until": "now"
+          }
+        ],
+        "title": "pyroscope.server.alloc_objects",
+        "type": "pyroscope-panel"
+      },
+      {
+        "datasource": "Pyroscope",
+        "gridPos": {
+          "h": 7,
+          "w": 24,
+          "x": 0,
+          "y": 13
+        },
+        "id": 6,
+        "targets": [
+          {
+            "format": "json",
+            "from": "now-1h",
+            "name": "pyroscope.server.alloc_space",
+            "queryType": "randomWalk",
+            "refId": "A",
+            "until": "now"
+          }
+        ],
+        "title": "pyroscope.server.alloc_space",
+        "type": "pyroscope-panel"
+      },
+      {
+        "datasource": "Pyroscope",
+        "gridPos": {
+          "h": 7,
+          "w": 24,
+          "x": 0,
+          "y": 20
+        },
+        "id": 3,
+        "targets": [
+          {
+            "format": "json",
+            "from": "now-1h",
+            "name": "pyroscope.server.inuse_objects",
+            "queryType": "randomWalk",
+            "refId": "A",
+            "until": "now"
+          }
+        ],
+        "title": "pyroscope.server.inuse_objects",
+        "type": "pyroscope-panel"
+      },
+      {
+        "datasource": "Pyroscope",
+        "gridPos": {
+          "h": 8,
+          "w": 24,
+          "x": 0,
+          "y": 27
+        },
+        "id": 4,
+        "targets": [
+          {
+            "format": "json",
+            "from": "now-1h",
+            "name": "pyroscope.server.inuse_space",
+            "queryType": "randomWalk",
+            "refId": "A",
+            "until": "now"
+          }
+        ],
+        "title": "pyroscope.server.inuse_space",
+        "type": "pyroscope-panel"
+      }
+    ],
+    "schemaVersion": 30,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+      "list": []
+    },
+    "time": {
+      "from": "now-6h",
+      "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "",
+    "title": "Pyroscope Server (Pyroscope)",
+    "uid": "J5dv1uG7z",
+    "version": 2
+  }


### PR DESCRIPTION
* Adding [Pyroscope](https://pyroscope.io/) for Continuous Profiling
* Adding dormant Grafana dashboards and data source for Pyroscope
* Add `--yolo` flag, to allow pulling `:latest` tags
* Fix errorlevel handling on cancel