### PR TITLE
feat: bump to latest dependencies

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3.5.3
+      uses: actions/checkout@v3.6.0
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.5.3
+        uses: actions/checkout@v3.6.0
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
 

--- a/dockerfiles/grafana/Dockerfile
+++ b/dockerfiles/grafana/Dockerfile
@@ -1,2 +1,2 @@
 # dependabot will update this file when base image is updated
-FROM grafana/grafana:10.0.2
+FROM grafana/grafana:10.1.1

--- a/dockerfiles/loki/Dockerfile
+++ b/dockerfiles/loki/Dockerfile
@@ -1,2 +1,2 @@
 # dependabot will update this file when base image is updated
-FROM grafana/loki:2.8.2
+FROM grafana/loki:2.8.4

--- a/dockerfiles/otel-collector/Dockerfile
+++ b/dockerfiles/otel-collector/Dockerfile
@@ -1,2 +1,2 @@
 # dependabot will update this file when base image is updated
-FROM otel/opentelemetry-collector-contrib:0.81.0
+FROM otel/opentelemetry-collector-contrib:0.84.0

--- a/dockerfiles/prometheus/Dockerfile
+++ b/dockerfiles/prometheus/Dockerfile
@@ -1,2 +1,2 @@
 # dependabot will update this file when base image is updated
-FROM prom/prometheus:v2.45.0
+FROM prom/prometheus:v2.46.0

--- a/internal/files/files/grafana/run-o11y-run/docker-compose.yaml
+++ b/internal/files/files/grafana/run-o11y-run/docker-compose.yaml
@@ -3,7 +3,7 @@ version: "3.8"
 services:
 
   grafana:
-    image: grafana/grafana:10.0.2
+    image: grafana/grafana:10.1.1
     volumes:
       - ../shared/grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
       # - ../shared/pyroscope/grafana-provisioning:/etc/grafana/provisioning
@@ -20,7 +20,7 @@ services:
       - "3000:3000"
 
   loki:
-    image: grafana/loki:2.8.2
+    image: grafana/loki:2.8.4
     command: "-config.file=/etc/loki/local-config.yaml"
     environment:
       - NO_PROXY=grafana,loki,minio,otel-collector,prometheus,pyroscope,tempo
@@ -64,7 +64,7 @@ services:
       retries: 5
 
   otel-collector:
-    image: otel/opentelemetry-collector-contrib:0.81.0
+    image: otel/opentelemetry-collector-contrib:0.84.0
     command: [ "--config=/etc/otel-collector.yaml" ]
     volumes:
       - ../shared/otel-collector.yaml:/etc/otel-collector.yaml
@@ -82,7 +82,7 @@ services:
       - tempo
 
   prometheus:
-    image: prom/prometheus:v2.45.0
+    image: prom/prometheus:v2.46.0
     command:
       - --config.file=/etc/prometheus.yaml
       - --web.enable-remote-write-receiver


### PR DESCRIPTION
Bump:

* `grafana/grafana:10.0.2` => `grafana/grafana:10.1.1`
* `grafana/loki:2.8.2` => `grafana/loki:2.8.4`
* `otel/opentelemetry-collector-contrib:0.81.0` => `otel/opentelemetry-collector-contrib:0.84.0`
* `prom/prometheus:v2.45.0` => `prom/prometheus:v2.46.0`