### PR TITLE
Upgrades the run-o11y-run stack, plus required changes

### DIFF
--- a/internal/files/files/grafana/run-o11y-run/docker-compose.yaml
+++ b/internal/files/files/grafana/run-o11y-run/docker-compose.yaml
@@ -1,7 +1,7 @@
 services:
 
   grafana:
-    image: grafana/grafana:11.4.0
+    image: grafana/grafana:12.2.0
     container_name: grafana
     volumes:
       - ../shared/grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
@@ -11,6 +11,7 @@ services:
       - GF_AUTH_ANONYMOUS_ENABLED=true
       - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
       - GF_AUTH_DISABLE_LOGIN_FORM=true
+      - GF_ANALYTICS_REPORTING_ENABLED=false
       # https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/feature-toggles/
       - GF_FEATURE_TOGGLES_ENABLE=traceqlEditor,traceToMetrics,publicDashboards,showTraceId,pyroscopeFlameGraph,correlations
       # - GF_INSTALL_PLUGINS=pyroscope-datasource,pyroscope-panel
@@ -19,7 +20,7 @@ services:
       - "3000:3000"
 
   loki:
-    image: grafana/loki:3.3.1
+    image: grafana/loki:3.5.5
     container_name: loki
     command: "-config.file=/etc/loki/local-config.yaml"
     environment:
@@ -30,6 +31,7 @@ services:
       - 9095
     volumes:
       - ../shared/loki.yaml:/etc/loki/local-config.yaml
+      - ./loki-data:/loki
     depends_on:
       - minio
     healthcheck:
@@ -65,7 +67,7 @@ services:
       retries: 5
 
   otel-collector:
-    image: otel/opentelemetry-collector-contrib:0.115.1
+    image: otel/opentelemetry-collector-contrib:0.136.0
     container_name: otel-collector
     command: [ "--config=/etc/otel-collector.yaml" ]
     volumes:
@@ -86,7 +88,7 @@ services:
       - tempo
 
   prometheus:
-    image: prom/prometheus:v3.0.1
+    image: prom/prometheus:v3.6.0
     container_name: prometheus
     command:
       - --config.file=/etc/prometheus.yaml

--- a/internal/files/files/grafana/shared/loki.yaml
+++ b/internal/files/files/grafana/shared/loki.yaml
@@ -35,3 +35,8 @@ ruler:
 
 limits_config:
   allow_structured_metadata: true
+
+storage_config:
+  filesystem:
+    directory: /loki/chunks
+

--- a/internal/files/files/grafana/shared/loki.yaml
+++ b/internal/files/files/grafana/shared/loki.yaml
@@ -32,3 +32,6 @@ ruler:
   storage:
     s3:
       bucketnames: loki-ruler
+
+limits_config:
+  allow_structured_metadata: true

--- a/internal/files/files/grafana/shared/otel-collector.yaml.tmpl
+++ b/internal/files/files/grafana/shared/otel-collector.yaml.tmpl
@@ -35,10 +35,11 @@ receivers:
 
 processors:
   batch:
+  deltatocumulative:
 
 exporters:
-  loki:
-    endpoint: http://loki:3100/loki/api/v1/push
+  otlphttp/loki:
+    endpoint: http://loki:3100/otlp/
     tls:
       insecure: true
   prometheusremotewrite:
@@ -59,9 +60,10 @@ service:
       receivers: [otlp, syslog]
     {{- end }}
       processors: [batch]
-      exporters: [loki]
+      exporters: [otlphttp/loki]
     metrics:
       receivers: [otlp]
+      processors: [deltatocumulative, batch]
       exporters: [prometheusremotewrite]
     traces:
       receivers: [otlp]

--- a/internal/files/files/grafana/shared/pyroscope/grafana-provisioning/main.yml
+++ b/internal/files/files/grafana/shared/pyroscope/grafana-provisioning/main.yml
@@ -6,3 +6,6 @@ providers:
     updateIntervalSeconds: 5
     options:
       path: /etc/grafana/provisioning/dashboards
+
+analytics:
+  reporting_enabled: false

--- a/internal/files/files/grafana/shared/tempo.yaml
+++ b/internal/files/files/grafana/shared/tempo.yaml
@@ -44,3 +44,6 @@ storage:
 
 overrides:
   metrics_generator_processors: [service-graphs, span-metrics] # enables metrics generator
+
+usage_report:
+  reporting_enabled: false


### PR DESCRIPTION
This PR upgrades the `run-o11y-run` stack to the current version of container versions, and the subsequent required changes in order to support that upgrade. 

These changes also fixes the sending of metrics through from `opentelemetry-collector-contrib` to `prometheus` via remote write. 

Changelog: 
* Updates Grafana to version 12.2.0
* Updates Grafana Loki to version 3.5.5
  * Explicitly enables structured metadata for ingested logs
  * Creates a mount point for Loki data, as ingesting logs requires directory creation and this fails on a RO filesystem
  * Adds chunk storage location to Loki configuration
* Updates opentelemetry-collector-contrib to version 0.136.0
  * Rewires the log sending to Loki to OTLP over http, as the Loki exporter is deprecated in 0.130.0 as the exporter was end-of-lifed in July 2024
  * Adds additional processor for `deltatocumulative`
* Disables Grafana usage reporting
* Disables Tempo usage reporting
* Disables Pyroscope usage reporting