### PR TITLE
Adds proxy plubming, tempo config fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ The underlying observability stack is built on [Grafana](https://grafana.com/) p
 
 `run-o11y-run` depends on the latest version of [Docker Desktop](https://www.docker.com/products/docker-desktop/), which includes the `docker compose` command.
 
+In order to use the local alpaca proxy, you will also need to have the ANZ CA Bundle, that can be extracted with: `security find-certificate -c "ANZ" -p -a >> ~/.ssl/anz_ca_bundle.pem`
+
 ## Quick Start
 
 ### Install

--- a/internal/files/files/grafana/run-o11y-run/docker-compose.yaml
+++ b/internal/files/files/grafana/run-o11y-run/docker-compose.yaml
@@ -1,5 +1,4 @@
 services:
-
   grafana:
     image: grafana/grafana:12.2.0
     container_name: grafana
@@ -7,6 +6,7 @@ services:
       - ../shared/grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
       # - ../shared/pyroscope/grafana-provisioning:/etc/grafana/provisioning
       # - ../shared/pyroscope-dashboard.json:/etc/grafana/provisioning/dashboards/dashboard.json
+      - ${HOME}/.ssl/anz_ca_bundle.pem:/etc/ssl/certs/anz_ca_bundle.pem:ro
     environment:
       - GF_AUTH_ANONYMOUS_ENABLED=true
       - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
@@ -15,7 +15,12 @@ services:
       # https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/feature-toggles/
       - GF_FEATURE_TOGGLES_ENABLE=traceqlEditor,traceToMetrics,publicDashboards,showTraceId,pyroscopeFlameGraph,correlations
       # - GF_INSTALL_PLUGINS=pyroscope-datasource,pyroscope-panel
-      - NO_PROXY=grafana,loki,minio,otel-collector,prometheus,pyroscope,tempo
+      - HTTP_PROXY=http://host.docker.internal:3128
+      - HTTPS_PROXY=http://host.docker.internal:3128
+      - NO_PROXY=localhost,127.0.0.1,host.docker.internal,grafana,loki,minio,otel-collector,prometheus,pyroscope,tempo,172.18.0.0/16
+      - http_proxy=http://host.docker.internal:3128
+      - https_proxy=http://host.docker.internal:3128
+      - no_proxy=localhost,127.0.0.1,host.docker.internal,grafana,loki,minio,otel-collector,prometheus,pyroscope,tempo,172.18.0.0/16
     ports:
       - "3000:3000"
 
@@ -24,12 +29,18 @@ services:
     container_name: loki
     command: "-config.file=/etc/loki/local-config.yaml"
     environment:
-      - NO_PROXY=grafana,loki,minio,otel-collector,prometheus,pyroscope,tempo
+      - HTTP_PROXY=http://host.docker.internal:3128
+      - HTTPS_PROXY=http://host.docker.internal:3128
+      - NO_PROXY=localhost,127.0.0.1,host.docker.internal,grafana,loki,minio,otel-collector,prometheus,pyroscope,tempo,172.18.0.0/16
+      - http_proxy=http://host.docker.internal:3128
+      - https_proxy=http://host.docker.internal:3128
+      - no_proxy=localhost,127.0.0.1,host.docker.internal,grafana,loki,minio,otel-collector,prometheus,pyroscope,tempo,172.18.0.0/16
     ports:
       - "3100:3100"
       - 7946
       - 9095
     volumes:
+      - ${HOME}/.ssl/anz_ca_bundle.pem:/etc/ssl/certs/anz_ca_bundle.pem:ro
       - ../shared/loki.yaml:/etc/loki/local-config.yaml
       - ./loki-data:/loki
     depends_on:
@@ -55,10 +66,16 @@ services:
       - MINIO_ROOT_PASSWORD=supersecret
       - MINIO_PROMETHEUS_AUTH_TYPE=public
       - MINIO_UPDATE=off
-      - NO_PROXY=grafana,loki,minio,otel-collector,prometheus,pyroscope,tempo
+      - HTTP_PROXY=http://host.docker.internal:3128
+      - HTTPS_PROXY=http://host.docker.internal:3128
+      - NO_PROXY=localhost,127.0.0.1,host.docker.internal,grafana,loki,minio,otel-collector,prometheus,pyroscope,tempo,172.18.0.0/16
+      - http_proxy=http://host.docker.internal:3128
+      - https_proxy=http://host.docker.internal:3128
+      - no_proxy=localhost,127.0.0.1,host.docker.internal,grafana,loki,minio,otel-collector,prometheus,pyroscope,tempo,172.18.0.0/16
     ports:
       - 9000
     volumes:
+      - ${HOME}/.ssl/anz_ca_bundle.pem:/etc/ssl/certs/anz_ca_bundle.pem:ro
       - ./minio-data:/data
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://localhost:9000/minio/health/live" ]
@@ -71,6 +88,7 @@ services:
     container_name: otel-collector
     command: [ "--config=/etc/otel-collector.yaml" ]
     volumes:
+      - ${HOME}/.ssl/anz_ca_bundle.pem:/etc/ssl/certs/anz_ca_bundle.pem:ro
       - ../shared/otel-collector.yaml:/etc/otel-collector.yaml
       - /var/log:/var/log
       - "../../../../:/app:r"
@@ -81,7 +99,12 @@ services:
       - "18888:18888"   # prometheus
     environment:
       - DEBUG=true
-      - NO_PROXY=grafana,loki,minio,otel-collector,prometheus,pyroscope,tempo
+      - HTTP_PROXY=http://host.docker.internal:3128
+      - HTTPS_PROXY=http://host.docker.internal:3128
+      - NO_PROXY=localhost,127.0.0.1,host.docker.internal,grafana,loki,minio,otel-collector,prometheus,pyroscope,tempo,172.18.0.0/16
+      - http_proxy=http://host.docker.internal:3128
+      - https_proxy=http://host.docker.internal:3128
+      - no_proxy=localhost,127.0.0.1,host.docker.internal,grafana,loki,minio,otel-collector,prometheus,pyroscope,tempo,172.18.0.0/16
     depends_on:
       - loki
       - prometheus
@@ -95,11 +118,17 @@ services:
       - --web.enable-remote-write-receiver
       - --enable-feature=exemplar-storage
     volumes:
+      - ${HOME}/.ssl/anz_ca_bundle.pem:/etc/ssl/certs/anz_ca_bundle.pem:ro
       - ../shared/prometheus.yaml:/etc/prometheus.yaml
     ports:
       - "9090:9090"
     environment:
-      - NO_PROXY=grafana,loki,minio,otel-collector,prometheus,pyroscope,tempo
+      - HTTP_PROXY=http://host.docker.internal:3128
+      - HTTPS_PROXY=http://host.docker.internal:3128
+      - NO_PROXY=localhost,127.0.0.1,host.docker.internal,grafana,loki,minio,otel-collector,prometheus,pyroscope,tempo,172.18.0.0/16
+      - http_proxy=http://host.docker.internal:3128
+      - https_proxy=http://host.docker.internal:3128
+      - no_proxy=localhost,127.0.0.1,host.docker.internal,grafana,loki,minio,otel-collector,prometheus,pyroscope,tempo,172.18.0.0/16
 
   pyroscope:
     image: pyroscope/pyroscope:0.37.2
@@ -109,15 +138,23 @@ services:
     command:
       - server
     environment:
-      - NO_PROXY=grafana,loki,minio,otel-collector,prometheus,pyroscope,tempo
       - PYROSCOPE_LOG_LEVEL=info
       - PYROSCOPE_WAIT_AFTER_STOP=true
+      - HTTP_PROXY=http://host.docker.internal:3128
+      - HTTPS_PROXY=http://host.docker.internal:3128
+      - NO_PROXY=localhost,127.0.0.1,host.docker.internal,grafana,loki,minio,otel-collector,prometheus,pyroscope,tempo,172.18.0.0/16
+      - http_proxy=http://host.docker.internal:3128
+      - https_proxy=http://host.docker.internal:3128
+      - no_proxy=localhost,127.0.0.1,host.docker.internal,grafana,loki,minio,otel-collector,prometheus,pyroscope,tempo,172.18.0.0/16
+    volumes:
+      - ${HOME}/.ssl/anz_ca_bundle.pem:/etc/ssl/certs/anz_ca_bundle.pem:ro
 
   tempo:
-    image: grafana/tempo:2.6.1
+    image: grafana/tempo:2.8.2
     container_name: tempo
     command: [ "-config.file=/etc/tempo.yaml" ]
     volumes:
+      - ${HOME}/.ssl/anz_ca_bundle.pem:/etc/ssl/certs/anz_ca_bundle.pem:ro
       - ../shared/tempo.yaml:/etc/tempo.yaml
       - ./tempo-data:/tmp/tempo
     ports:
@@ -126,4 +163,9 @@ services:
       - "9095:9095"   # tempo grpc
       - "9411:9411"   # zipkin
     environment:
-      - NO_PROXY=grafana,loki,minio,otel-collector,prometheus,pyroscope,tempo
+      - HTTP_PROXY=http://host.docker.internal:3128
+      - HTTPS_PROXY=http://host.docker.internal:3128
+      - NO_PROXY=localhost,127.0.0.1,host.docker.internal,grafana,loki,minio,otel-collector,prometheus,pyroscope,tempo,172.18.0.0/16
+      - http_proxy=http://host.docker.internal:3128
+      - https_proxy=http://host.docker.internal:3128
+      - no_proxy=localhost,127.0.0.1,host.docker.internal,grafana,loki,minio,otel-collector,prometheus,pyroscope,tempo,172.18.0.0/16

--- a/internal/files/files/grafana/shared/tempo.yaml
+++ b/internal/files/files/grafana/shared/tempo.yaml
@@ -1,21 +1,31 @@
 server:
+  http_listen_address: 0.0.0.0
   http_listen_port: 3200
+  grpc_listen_port: 9095
 
 distributor:
   receivers:                           # this configuration will listen on all ports and protocols that tempo is capable of.
-    jaeger:                            # the receives all come from the OpenTelemetry collector.  more configuration information can
-      protocols:                       # be found there: https://github.com/open-telemetry/opentelemetry-collector/tree/main/receiver
+    jaeger:                            # the receivers all come from the OpenTelemetry collector. more configuration information can
+      protocols:                       # be found here: https://github.com/open-telemetry/opentelemetry-collector/tree/main/receiver
         thrift_http:                   #
+          endpoint: "0.0.0.0:14268"    #
         grpc:                          # for a production deployment you should only enable the receivers you need!
+          endpoint: "0.0.0.0:14250"
         thrift_binary:
+          endpoint: "0.0.0.0:6832"
         thrift_compact:
+          endpoint: "0.0.0.0:6831"
     zipkin:
+      endpoint: "0.0.0.0:9411"
     otlp:
       protocols:
         http:
+          endpoint: "0.0.0.0:4318"
         grpc:
+          endpoint: "0.0.0.0:4317"
     opencensus:
-
+      endpoint: "0.0.0.0:55678"
+  
 ingester:
   max_block_duration: 5m               # cut the headblock when this much time passes. this is being set for demo purposes and should probably be left alone normally
 
@@ -28,11 +38,17 @@ metrics_generator:
     external_labels:
       source: tempo
       cluster: docker-compose
+  processor:
+    local_blocks:
+      flush_to_storage: true
+      filter_server_spans: false
   storage:
     path: /tmp/tempo/generator/wal
     remote_write:
       - url: http://prometheus:9090/api/v1/write
         send_exemplars: true
+  traces_storage:
+    path: /tmp/tempo/generator/traces
 
 storage:
   trace:
@@ -43,7 +59,12 @@ storage:
       path: /tmp/tempo/blocks
 
 overrides:
-  metrics_generator_processors: [service-graphs, span-metrics] # enables metrics generator
+  defaults:
+    metrics_generator:
+      processors:
+        - service-graphs
+        - span-metrics
+        - local-blocks
 
 usage_report:
   reporting_enabled: false


### PR DESCRIPTION
This PR adds through the plumbing for the local alpaca configuration, as well as mounting the required ANZ CA bundle. 

Changelog:
* Plumbs through the proxy configuration
  * Mounts the ANZ CA bundle so that SSL certificate errors do not occur
  * Adds exceptions for the docker network
* Upgrades Tempo to 2.8.2
  * Various Tempo configuration changes as the update to current meant breaking changes in default behaviour

Known Issues: 
1. There's _something_ in Grafana that's still attempting to send grpc requests to the configured temp HTTP api endpoint: 
 ```logger=grafana-apiserver t=2025-10-02T01:19:31.749143167Z level=info msg="[core] [Channel #2 SubChannel #3]grpc: addrConn.createTransport failed to connect to {Addr: \"tempo:3200\", ServerName: \"tempo:3200\", }. Err: connection error: desc = \"error reading server preface: http2: failed reading the frame payload: http2: frame too large, note that the frame header looked like an HTTP/1.1 header\""```

I suspect it's something in the Drilldown plugin interface, but it doesn't seem to impact anything. Documenting this just in case. Traces, Metrics and Logs are all tested to be fully flowing through so I'm really unsure as to why, or what is generating these requests. 